### PR TITLE
Fix SIGTRAP crash from continuation misuse in connection handling

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -432,6 +432,8 @@ actor MCPConnectionManager {
         self.transport = NetworkTransport(
             connection: connection,
             logger: nil,
+            heartbeatConfig: .init(enabled: false),
+            reconnectionConfig: .disabled,
             bufferConfig: .unlimited
         )
 
@@ -627,6 +629,7 @@ actor ServerNetworkManager {
     private var connections: [UUID: MCPConnectionManager] = [:]
     private var connectionTasks: [UUID: Task<Void, Never>] = [:]
     private var pendingConnections: [UUID: String] = [:]
+    private var removedConnections: Set<UUID> = []
 
     typealias ConnectionApprovalHandler = @Sendable (UUID, MCP.Client.Info) async -> Bool
     private var connectionApprovalHandler: ConnectionApprovalHandler?
@@ -764,11 +767,20 @@ actor ServerNetworkManager {
         connections.removeAll()
         connectionTasks.removeAll()
         pendingConnections.removeAll()
+        removedConnections.removeAll()
 
         await discoveryManager?.stop()
     }
 
     func removeConnection(_ id: UUID) async {
+        // Guard against redundant removal — calling stop() on an already-stopped
+        // connection can trigger a double-resume in the SDK's transport continuation.
+        guard !removedConnections.contains(id) else {
+            log.debug("Connection \(id) already removed, skipping")
+            return
+        }
+        removedConnections.insert(id)
+
         log.debug("Removing connection: \(id)")
 
         if let connectionManager = connections[id] {


### PR DESCRIPTION
## Summary
- The MCP SDK's `NetworkTransport` has reconnection logic that creates unstructured tasks holding `CheckedContinuation` references. For server-side incoming connections, this reconnection path can cause a double-resume when connections are cancelled, crashing the app with SIGTRAP
- Disable reconnection and heartbeats for server-accepted connections since they are client features — if a client disconnects, it should reconnect itself
- Make `removeConnection` idempotent to prevent `stop()` being called twice on the same connection

## Context
Crash report shows:
```
SWIFT TASK CONTINUATION MISUSE: connect() leaked its continuation without resuming it.
SWIFT TASK CONTINUATION MISUSE: connect() tried to resume its continuation more than once,
  throwing [-32603] Internal error: Connection cancelled!
```
This occurs when Claude Desktop opens 25+ simultaneous connections via Bonjour.

## Test plan
- [ ] Launch iMCP and connect from Claude Desktop
- [ ] Verify connections establish without SIGTRAP crash
- [ ] Verify the app stays running when clients disconnect and reconnect
- [ ] Verify tool calls still work through established connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)