### PR TITLE
Wire up Sparkle so the app actually checks for updates

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -1,4 +1,5 @@
 import MenuBarExtraAccess
+import Sparkle
 import SwiftUI
 
 @main
@@ -7,12 +8,23 @@ struct App: SwiftUI.App {
     @AppStorage("isEnabled") private var isEnabled = true
     @State private var isMenuPresented = false
 
+    // `startingUpdater: true` makes this the sole owner of update checking for
+    // the app's lifetime. Without it (or without ever constructing an updater
+    // at all), the SUFeedURL / SUPublicEDKey keys in Info.plist are inert and
+    // installs never learn about newer releases, no matter how long they run.
+    private let updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: nil
+    )
+
     var body: some Scene {
         MenuBarExtra("iMCP", image: #"MenuIcon-\#(isEnabled ? "On" : "Off")"#) {
             ContentView(
                 serverManager: serverController,
                 isEnabled: $isEnabled,
-                isMenuPresented: $isMenuPresented
+                isMenuPresented: $isMenuPresented,
+                updater: updaterController.updater
             )
         }
         .menuBarExtraStyle(.window)

--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import MenuBarExtraAccess
+import Sparkle
 import SwiftUI
 
 struct ContentView: View {
@@ -9,6 +10,7 @@ struct ContentView: View {
     @Environment(\.openSettings) private var openSettings
 
     private let aboutWindowController: AboutWindowController
+    private let updater: SPUUpdater
 
     private var serviceConfigs: [ServiceConfig] {
         serverController.computedServiceConfigs
@@ -25,12 +27,14 @@ struct ContentView: View {
     init(
         serverManager: ServerController,
         isEnabled: Binding<Bool>,
-        isMenuPresented: Binding<Bool>
+        isMenuPresented: Binding<Bool>,
+        updater: SPUUpdater
     ) {
         self.serverController = serverManager
         self._isEnabled = isEnabled
         self._isMenuPresented = isMenuPresented
         self.aboutWindowController = AboutWindowController()
+        self.updater = updater
     }
 
     var body: some View {
@@ -103,6 +107,11 @@ struct ContentView: View {
                 MenuButton("Settings...", isMenuPresented: $isMenuPresented) {
                     openSettings()
                 }
+
+                MenuButton("Check for Updates...", isMenuPresented: $isMenuPresented) {
+                    updater.checkForUpdates()
+                }
+                .disabled(!updater.canCheckForUpdates)
 
                 MenuButton("About iMCP", isMenuPresented: $isMenuPresented) {
                     aboutWindowController.showWindow(nil)

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		F825BDC12D9AD00E0063ADD7 /* UnixSignals in Frameworks */ = {isa = PBXBuildFile; productRef = F825BDC02D9AD00E0063ADD7 /* UnixSignals */; };
 		F873F48D2D712BCF0035CD0A /* Ontology in Frameworks */ = {isa = PBXBuildFile; productRef = F873F48C2D712BCF0035CD0A /* Ontology */; };
 		F87796FC2E0764AE00328CC6 /* MenuBarExtraAccess in Frameworks */ = {isa = PBXBuildFile; productRef = F87796FB2E0764AE00328CC6 /* MenuBarExtraAccess */; };
+		158948D22D0E610E83A4433C /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B75D49165A453E912E36DBFE /* Sparkle */; };
 		F88358372D64A085000317CD /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = F88358362D64A085000317CD /* Logging */; };
 		F885C6B82D66079100963B25 /* imcp-server in Copy Executables */ = {isa = PBXBuildFile; fileRef = F8F44EB62D5908D00075D79C /* imcp-server */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F8A7DE3E2DCB76F700530587 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = F8A7DE3D2DCB76F700530587 /* MCP */; };
@@ -103,6 +104,7 @@
 			files = (
 				F809556E2D7888920055B911 /* TypedStream in Frameworks */,
 				F87796FC2E0764AE00328CC6 /* MenuBarExtraAccess in Frameworks */,
+				158948D22D0E610E83A4433C /* Sparkle in Frameworks */,
 				F873F48D2D712BCF0035CD0A /* Ontology in Frameworks */,
 				F8D7C31A2DCBD32100A4775F /* MCP in Frameworks */,
 				F8A7DE3E2DCB76F700530587 /* MCP in Frameworks */,
@@ -224,6 +226,7 @@
 				F8D7C3192DCBD32100A4775F /* MCP */,
 				F8D8C48D2DCE0E6800369E5C /* JSONSchema */,
 				F87796FB2E0764AE00328CC6 /* MenuBarExtraAccess */,
+				B75D49165A453E912E36DBFE /* Sparkle */,
 			);
 			productName = iMCP;
 			productReference = F8F44E6D2D59038D0075D79C /* iMCP.app */;
@@ -290,6 +293,7 @@
 				F8D7C3182DCBD32100A4775F /* XCRemoteSwiftPackageReference "swift-sdk" */,
 				F8D8C48C2DCE0E6800369E5C /* XCRemoteSwiftPackageReference "JSONSchema" */,
 				F87796FA2E0764AE00328CC6 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */,
+				26120478122FBFCB2B073DE5 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F8F44E6E2D59038D0075D79C /* Products */;
@@ -768,6 +772,14 @@
 				minimumVersion = 1.3.0;
 			};
 		};
+		26120478122FBFCB2B073DE5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -846,6 +858,11 @@
 		F8F44E9C2D5903F70075D79C /* MCP */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MCP;
+		};
+		B75D49165A453E912E36DBFE /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 26120478122FBFCB2B073DE5 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0604c8a8c049fb6e696fcd8af68cdc36f2f23f938eec962e31f24cc19d550d45",
+  "originHash" : "ef84066429fbd998da047140f11ad84f410b82811512bb502cfd69ad588f22d1",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "3d1d2545b826909a3f6499f2ef661429bf9c10d5",
         "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {


### PR DESCRIPTION
## Summary

iMCP never checks for updates. Every install is stuck on whatever version it first shipped — silently, with no error, no in-app way to check, and no prompt when a fix ships.

`Info.plist` declares `SUFeedURL`, `SUPublicEDKey`, and `SUEnableInstallerLauncherService` — it looks like Sparkle is configured — but no target links the Sparkle package and no code constructs an updater, so those keys are dead. This PR links Sparkle and wires it up.

## Root cause

Found on a real install stuck on v1.4.0 (Jan 2026 build), still hitting the `ServiceGroupError` fatal crash from #166 three months after the fix shipped in v1.4.1. There's no `SPUStandardUpdaterController` or equivalent anywhere in the codebase, so the Sparkle keys in Info.plist are config with nothing reading them.

## Fix

- Add the Sparkle SPM package to the `iMCP` app target.
- Construct `SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)` in `App.swift`, using the existing `SUFeedURL`/`SUPublicEDKey`.
- Add a "Check for Updates..." item to the menu bar dropdown, wired to `updater.checkForUpdates()`.

## Test plan

- [x] `xcodebuild -resolvePackageDependencies` resolves Sparkle (2.9.6) alongside existing deps
- [x] `xcodebuild build -scheme iMCP -configuration Debug` succeeds
- [x] Built app launches and stays running with `Sparkle.framework` loaded
- [x] `xcodebuild test -scheme imcp-serverTests` — all pass, including `ServiceGroupConfigurationTests` (unrelated, confirms no regression)
- [x] `swift format lint --strict --recursive .` — clean
- [ ] Not verified: an actual update install against a live appcast, or a codesigned/notarized Release build. I don't hold the `TTY35UM57S` Developer ID or the WeatherKit entitlement, so CI's signed build is the real check for that.

## Scope / non-goals

`downloads.imcp.app` (the configured `SUFeedURL`) doesn't resolve — NXDOMAIN. This makes the app actually attempt update checks, but they'll fail until that domain is live. No `appcast.xml` or publish workflow in this repo, so I can't tell if it's stale or just needs DNS pointed at wherever the appcast is hosted.

Closes #52.