### PR TITLE
Play confirmation sound when copying server command

### DIFF
--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -91,6 +91,8 @@ struct ContentView: View {
                     let pasteboard = NSPasteboard.general
                     pasteboard.clearContents()
                     pasteboard.setString(command, forType: .string)
+
+                    _ = NSSound.play(.pop)
                 }
             }
             .padding(.top, 8)


### PR DESCRIPTION
## Summary

"Copy server command to clipboard" gives no feedback, so there is no way to tell whether the click registered. Users click again, or paste to check.

This plays the system Pop sound on copy — the same kind of cue the app already uses elsewhere — so the action confirms itself.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Clicking the menu item plays the sound and the command is on the clipboard