### PR TITLE
Add accessibility labels to service toggle buttons

### DIFF
--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -41,6 +41,9 @@ struct ServiceToggleView: View {
             .buttonStyle(PlainButtonStyle())
             .disabled(!isEnabled)
             .frame(width: buttonSize, height: buttonSize)
+            .accessibilityLabel(config.name)
+            .accessibilityValue(config.binding.wrappedValue ? "Enabled" : "Disabled")
+            .accessibilityAddTraits(.isButton)
 
             Text(config.name)
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary

VoiceOver reads each service row as an unlabeled icon button plus a separate text element, with no indication of on/off state. Screen-reader users can't tell which services are enabled, in an app whose main control surface is exactly these toggles.

This adds an accessibility label, value, and button trait to each toggle so it reads as e.g. "Calendar, Enabled".

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Accessibility tree exposes named elements with state (verified via System Events)
- [ ] Full VoiceOver walkthrough