### PR TITLE
Make service rows fully interactive with hover and press feedback

### DIFF
--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -41,6 +41,9 @@ struct ServiceToggleView: View {
             .buttonStyle(PlainButtonStyle())
             .disabled(!isEnabled)
             .frame(width: buttonSize, height: buttonSize)
+            .accessibilityLabel(config.name)
+            .accessibilityValue(config.binding.wrappedValue ? "Enabled" : "Disabled")
+            .accessibilityAddTraits(.isButton)
 
             Text(config.name)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -1,9 +1,10 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 struct ServiceToggleView: View {
     let config: ServiceConfig
     @State private var isServiceActivated = false
+    @State private var isHovering = false
 
     // MARK: Environment
     @Environment(\.colorScheme) private var colorScheme
@@ -14,19 +15,19 @@ struct ServiceToggleView: View {
     private let imagePadding: CGFloat = 5
 
     var body: some View {
-        HStack {
-            Button(action: {
-                config.binding.wrappedValue.toggle()
-                if config.binding.wrappedValue && !isServiceActivated {
-                    Task {
-                        do {
-                            try await config.service.activate()
-                        } catch {
-                            config.binding.wrappedValue = false
-                        }
+        Button(action: {
+            config.binding.wrappedValue.toggle()
+            if config.binding.wrappedValue && !isServiceActivated {
+                Task {
+                    do {
+                        try await config.service.activate()
+                    } catch {
+                        config.binding.wrappedValue = false
                     }
                 }
-            }) {
+            }
+        }) {
+            HStack {
                 Circle()
                     .fill(buttonBackgroundColor)
                     .overlay(
@@ -36,21 +37,36 @@ struct ServiceToggleView: View {
                             .foregroundColor(buttonForegroundColor)
                             .padding(imagePadding)
                     )
+                    .frame(width: buttonSize, height: buttonSize)
                     .animation(.snappy, value: config.binding.wrappedValue || isEnabled)
-            }
-            .buttonStyle(PlainButtonStyle())
-            .disabled(!isEnabled)
-            .frame(width: buttonSize, height: buttonSize)
-            .accessibilityLabel(config.name)
-            .accessibilityValue(config.binding.wrappedValue ? "Enabled" : "Disabled")
-            .accessibilityAddTraits(.isButton)
 
-            Text(config.name)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundColor(isEnabled ? Color.primary : .primary.opacity(0.5))
+                Text(config.name)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(isEnabled ? Color.primary : .primary.opacity(0.5))
+            }
+            .padding(.horizontal, 14)
+            .frame(height: buttonSize + 6)
+            .contentShape(Rectangle())
         }
-        .frame(height: buttonSize)
-        .padding(.horizontal, 14)
+        .buttonStyle(ServiceToggleRowStyle())
+        .disabled(!isEnabled)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovering && isEnabled ? Color.primary.opacity(0.07) : Color.clear)
+        )
+        .onHover { hovering in
+            isHovering = hovering && isEnabled
+        }
+        .onChange(of: isEnabled) { _, enabled in
+            if !enabled {
+                isHovering = false
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: isHovering)
+        .pointerStyle(isEnabled ? .link : .default)
+        .help("\(config.binding.wrappedValue ? "Disable" : "Enable") \(config.name)")
+        .accessibilityLabel(config.name)
+        .accessibilityValue(config.binding.wrappedValue ? "Enabled" : "Disabled")
         .task {
             isServiceActivated = await config.isActivated
         }
@@ -71,5 +87,15 @@ struct ServiceToggleView: View {
         } else {
             return .primary.opacity(isEnabled ? 0.7 : 0.4)
         }
+    }
+}
+
+// Press feedback for the whole row: a slight scale-down while the mouse is held.
+private struct ServiceToggleRowStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }
 }

--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -43,9 +43,18 @@ struct ServiceToggleView: View {
                 Text(config.name)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(isEnabled ? Color.primary : .primary.opacity(0.5))
+
+                // Display-only: clicks pass through so the whole row stays one control.
+                Toggle("", isOn: config.binding)
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .labelsHidden()
+                    .allowsHitTesting(false)
+                    .opacity(isEnabled ? 1.0 : 0.4)
+                    .accessibilityHidden(true)
             }
             .padding(.horizontal, 14)
-            .frame(height: buttonSize + 6)
+            .frame(height: buttonSize)
             .contentShape(Rectangle())
         }
         .buttonStyle(ServiceToggleRowStyle())


### PR DESCRIPTION
## Summary

Only the 26pt icon circle toggles a service. The label next to it is dead space, and nothing signals that the rows are clickable at all: no hover state, no cursor change, no press feedback. First-time users don't discover that clicking a service toggles it.

This makes each row one control with the affordances users expect:

- Whole row is the click target (label and empty space included)
- Hover highlight matching the menu's action rows
- Pointing-hand cursor over enabled rows
- Slight press scale-down
- Dynamic "Enable X" / "Disable X" tooltip
- A trailing switch reflecting state — display-only, clicks pass through, so the row stays a single control with an explicit "this toggles" signal

VoiceOver now sees one element per service instead of an unlabeled icon plus loose text.

Builds on #182; merging that first shrinks this diff to one commit.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Row click (including on the label) toggles the service; hover highlight and cursor change confirmed interactively
- [x] Accessibility tree shows one button per service row