### PR TITLE
Add per-row remove button to trusted clients list

### DIFF
--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -110,6 +110,14 @@ struct GeneralSettingsView: View {
                             Text(client)
                                 .font(.system(.body, design: .monospaced))
                             Spacer()
+                            Button {
+                                serverController.removeTrustedClient(client)
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Remove Client")
                         }
                         .contextMenu {
                             Button("Remove Client", role: .destructive) {


### PR DESCRIPTION
## Summary

Removing a single trusted client requires right-click → "Remove Client" or select-then-Delete. Neither is discoverable, while bulk "Remove All" has a visible button — so the destructive bulk action is easier to find than the targeted one.

This adds a visible ✕ button to each row, alongside the existing context menu and Delete-key paths.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Button renders per row and removes only that client