### PR TITLE
List enabled services in the connection approval dialog

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -381,6 +381,9 @@ final class ServerController: ObservableObject {
 
         approvalWindowController.showApprovalWindow(
             clientName: clientID,
+            enabledServiceNames: computedServiceConfigs
+                .filter { $0.binding.wrappedValue }
+                .map { $0.name },
             onApprove: { alwaysTrust in
                 if alwaysTrust {
                     self.addTrustedClient(clientID)

--- a/App/Views/ConnectionApprovalView.swift
+++ b/App/Views/ConnectionApprovalView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ConnectionApprovalView: View {
     let clientName: String
+    let enabledServiceNames: [String]
     let onApprove: (Bool) -> Void  // Bool parameter is for "always trust"
     let onDeny: () -> Void
 
@@ -26,10 +27,17 @@ struct ConnectionApprovalView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Allow \"\(clientName)\" to connect to iMCP?")
 
-                Text("This will give the client access to enabled services.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.leading)
+                if enabledServiceNames.isEmpty {
+                    Text("No services are currently enabled.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                } else {
+                    Text("This will give the client access to: \(enabledServiceNames.joined(separator: ", ")).")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
             }
 
             // Always trust checkbox
@@ -91,12 +99,14 @@ class ConnectionApprovalWindowController: NSObject {
 
     func showApprovalWindow(
         clientName: String,
+        enabledServiceNames: [String],
         onApprove: @escaping (Bool) -> Void,
         onDeny: @escaping () -> Void
     ) {
         // Create the SwiftUI view
         let approvalView = ConnectionApprovalView(
             clientName: clientName,
+            enabledServiceNames: enabledServiceNames,
             onApprove: { alwaysTrust in
                 onApprove(alwaysTrust)
                 self.closeWindow()
@@ -160,6 +170,7 @@ class ConnectionApprovalWindowController: NSObject {
 #Preview {
     ConnectionApprovalView(
         clientName: "Claude Desktop",
+        enabledServiceNames: ["Calendar", "Contacts", "Location"],
         onApprove: { alwaysTrust in
             print("Approved with always trust: \(alwaysTrust)")
         },


### PR DESCRIPTION
## Summary

The connection approval dialog says "This will give the client access to enabled services" without naming them. For a consent dialog, that's the one thing it should say: approving might expose Messages and Location, or nothing at all, and the user can't tell which.

The dialog now lists the enabled services by name ("This will give the client access to: Calendar, Contacts, Location."), or states that no services are currently enabled. Same pattern macOS's own permission prompts use — name the data being granted.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Dialog shows the current enabled-service names (SwiftUI preview + live connection)