### PR TITLE
Explain trusted clients in Settings

### DIFF
--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -90,18 +90,24 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Clients that automatically connect without approval.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Text(
+                        "Clients that connect automatically, without an approval dialog. A notification appears whenever one connects."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
                 .padding(.bottom, 4)
 
                 if trustedClients.isEmpty {
-                    HStack {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text("No trusted clients")
                             .foregroundStyle(.secondary)
                             .italic()
-                        Spacer()
+                        Text(
+                            "Clients appear here when you check \"Always trust this client\" while approving a connection."
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                     .padding(.vertical, 8)
                 } else {
@@ -124,6 +130,10 @@ struct GeneralSettingsView: View {
                         }
                         selectedClients.removeAll()
                     }
+
+                    Text("Clients are identified by the name they report, not by a verified identity.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
         }


### PR DESCRIPTION
## Summary

The Trusted Clients section doesn't explain itself: it never says how entries get there, that trusted clients connect silently (apart from a notification), or that trust is keyed to the client's self-reported name. Users meet the list without knowing what it controls.

Three copy changes, no behavior changes:

- Section caption now says trusted clients connect without a dialog and that a notification is posted when one connects
- Empty state explains how a client becomes trusted ("check 'Always trust this client' while approving a connection")
- Footnote discloses that clients are identified by the name they report, not a verified identity

## Test plan

- [x] `xcodebuild build` succeeds
- [x] All three strings render in Settings → General (empty state verified by code path; list was non-empty on the test machine)