### PR TITLE
Fix Settings window intermittently not appearing

### DIFF
--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -101,6 +101,12 @@ struct ContentView: View {
                 Divider()
 
                 MenuButton("Settings...", isMenuPresented: $isMenuPresented) {
+                    // iMCP is an accessory app (LSUIElement), so openSettings() alone is
+                    // unreliable here: it routes through a responder-chain action that only
+                    // lands when the app is already frontmost, which is ambiguous right as
+                    // this menu bar popover dismisses. Activate first, as the other
+                    // window-showing actions in this file already do.
+                    NSApp.activate(ignoringOtherApps: true)
                     openSettings()
                 }
 

--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -101,11 +101,7 @@ struct ContentView: View {
                 Divider()
 
                 MenuButton("Settings...", isMenuPresented: $isMenuPresented) {
-                    // iMCP is an accessory app (LSUIElement), so openSettings() alone is
-                    // unreliable here: it routes through a responder-chain action that only
-                    // lands when the app is already frontmost, which is ambiguous right as
-                    // this menu bar popover dismisses. Activate first, as the other
-                    // window-showing actions in this file already do.
+                    // openSettings() alone is unreliable for this accessory (LSUIElement) app.
                     NSApp.activate(ignoringOtherApps: true)
                     openSettings()
                 }


### PR DESCRIPTION
## Summary

Clicking "Settings..." in the menu sometimes does nothing — repeatedly. The failure is intermittent, which makes it look random, but it reproduces reliably on the first click after a fresh launch.

## Root cause

iMCP is an accessory app (`LSUIElement`), so `openSettings()` alone is unreliable: it routes through a responder-chain action that only lands when the app is frontmost, which is ambiguous right as the menu popover dismisses. Both other window-showing paths in the same file (About, connection approval) already work around this by calling `NSApp.activate(ignoringOtherApps: true)` first — Settings was the one path missing it.

## Fix

Activate the app before calling `openSettings()`, matching the existing pattern.

## Test plan

- [x] Reproduced pre-fix: fresh launch → first "Settings..." click does nothing
- [x] Post-fix: same cold-start click opens the window, repeatedly
- [x] `xcodebuild build` succeeds