### PR TITLE
Fix oversized menu panel after toggling MCP server off

### DIFF
--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @Environment(\.openSettings) private var openSettings
 
     private let aboutWindowController: AboutWindowController
+    @State private var contentHeight: CGFloat = 0
 
     private var serviceConfigs: [ServiceConfig] {
         serverController.computedServiceConfigs
@@ -72,9 +73,8 @@ struct ContentView: View {
                         await serverController.updateServiceBindings(serviceBindings)
                     }
                 }
-                .transition(.opacity.combined(with: .move(edge: .top)))
-                .animation(.easeInOut(duration: 0.3), value: isEnabled)
             }
+            // No animation: it desyncs this auto-sizing panel's frame from its content.
 
             VStack(alignment: .leading, spacing: 2) {
                 Divider()
@@ -117,7 +117,35 @@ struct ContentView: View {
             .padding(.horizontal, 2)
         }
         .padding(.vertical, 6)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            contentHeight = height
+            resizeMenuBarExtraWindow()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Material.thick)
+        .onChange(of: isMenuPresented) { _, presented in
+            if presented {
+                resizeMenuBarExtraWindow()
+            }
+        }
+    }
+
+    // MenuBarExtra's window keeps a stale taller frame when its content shrinks,
+    // leaving the content vertically centered in an oversized panel. Resize it to fit.
+    private func resizeMenuBarExtraWindow() {
+        DispatchQueue.main.async {
+            guard contentHeight > 0,
+                let window = NSApp.windows.first(where: { $0.className.contains("MenuBarExtraWindow") })
+            else { return }
+            let frame = window.frame
+            guard abs(frame.height - contentHeight) > 0.5 else { return }
+            window.setFrame(
+                NSRect(x: frame.minX, y: frame.maxY - contentHeight, width: frame.width, height: contentHeight),
+                display: true
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Toggling "Enable MCP Server" off leaves the menu as a large translucent panel with the compact content floating vertically centered inside it — transparent bands above and below, plus a stray border. Reopening the menu doesn't fix it; it looks broken until the server is toggled back on.

## Root cause

`MenuBarExtra`'s window-style panel only sizes itself at first presentation. When the Services section collapses, the panel keeps its stale taller frame (verified: window stuck at 501pt with content measuring 192pt) and the hosting view centers the undersized content in it. Presentation doesn't re-size either, which is why reopening doesn't help.

## Fix

Track the content's measured height (`onGeometryChange`) and resize the panel window to match, anchored at the top edge, re-applying on each presentation. The window is looked up by class name because MenuBarExtraAccess's introspection fails to find it on macOS 26. The collapse animation is removed so the frame can't lag the content, and the content is top-aligned as a fallback.

## Test plan

- [x] Reproduced pre-fix (menu open, toggle off → ghost panel)
- [x] Post-fix: panel resizes 501 → 192 in sync (verified via logged frames and screenshots), both directions, menu open throughout
- [x] Reopen after toggle shows correctly sized menu
- [x] `xcodebuild build` succeeds