### PR TITLE
Add per-tool toggles and show what each service exposes

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -181,6 +181,7 @@ final class ServerController: ObservableObject {
 
     // MARK: - AppStorage for Disabled Tools
     @AppStorage("disabledTools") private var disabledToolsData = Data()
+    private var disabledToolsGeneration = 0
 
     // MARK: - Computed Properties for Service Configurations and Bindings
     var computedServiceConfigs: [ServiceConfig] {
@@ -248,8 +249,9 @@ final class ServerController: ObservableObject {
         set {
             objectWillChange.send()
             disabledToolsData = (try? JSONEncoder().encode(newValue)) ?? Data()
-            let snapshot = newValue
-            Task { await networkManager.updateDisabledTools(snapshot) }
+            disabledToolsGeneration += 1
+            let generation = disabledToolsGeneration
+            Task { await networkManager.updateDisabledTools(newValue, generation: generation) }
         }
     }
 
@@ -295,7 +297,7 @@ final class ServerController: ObservableObject {
         Task {
             // Initialize bindings from AppStorage before the server starts.
             await networkManager.updateServiceBindings(self.currentServiceBindings)
-            await networkManager.updateDisabledTools(self.disabledTools)
+            await networkManager.updateDisabledTools(self.disabledTools, generation: 0)
             await self.networkManager.start()
             self.updateServerStatus("Running")
 
@@ -668,6 +670,7 @@ actor ServerNetworkManager {
     private let services = ServiceRegistry.services
     private var serviceBindings: [String: Binding<Bool>] = [:]
     private var disabledTools: Set<String> = []
+    private var disabledToolsLastGeneration = -1
 
     init() {
         do {
@@ -1079,8 +1082,11 @@ actor ServerNetworkManager {
         }
     }
 
-    // Update the disabled tool set.
-    func updateDisabledTools(_ newDisabledTools: Set<String>) async {
+    // Update the disabled tool set, discarding out-of-order deliveries.
+    func updateDisabledTools(_ newDisabledTools: Set<String>, generation: Int) async {
+        guard generation > disabledToolsLastGeneration else { return }
+        disabledToolsLastGeneration = generation
+
         guard disabledTools != newDisabledTools else { return }
         self.disabledTools = newDisabledTools
 

--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -269,6 +269,23 @@ final class ServerController: ObservableObject {
         disabledTools = tools
     }
 
+    func setService(_ config: ServiceConfig, enabled: Bool) {
+        objectWillChange.send()
+        config.binding.wrappedValue = enabled
+
+        Task {
+            if enabled, await !config.isActivated {
+                do {
+                    try await config.service.activate()
+                } catch {
+                    self.objectWillChange.send()
+                    config.binding.wrappedValue = false
+                }
+            }
+            await networkManager.updateServiceBindings(self.currentServiceBindings)
+        }
+    }
+
     // MARK: - Connection Approval Methods
     private func cleanupApprovalState() {
         pendingClientName = ""

--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -179,6 +179,9 @@ final class ServerController: ObservableObject {
     // MARK: - AppStorage for Trusted Clients
     @AppStorage("trustedClients") private var trustedClientsData = Data()
 
+    // MARK: - AppStorage for Disabled Tools
+    @AppStorage("disabledTools") private var disabledToolsData = Data()
+
     // MARK: - Computed Properties for Service Configurations and Bindings
     var computedServiceConfigs: [ServiceConfig] {
         ServiceRegistry.configureServices(
@@ -237,6 +240,33 @@ final class ServerController: ObservableObject {
         trustedClients = Set<String>()
     }
 
+    // MARK: - Disabled Tools Management
+    var disabledTools: Set<String> {
+        get {
+            (try? JSONDecoder().decode(Set<String>.self, from: disabledToolsData)) ?? []
+        }
+        set {
+            objectWillChange.send()
+            disabledToolsData = (try? JSONEncoder().encode(newValue)) ?? Data()
+            let snapshot = newValue
+            Task { await networkManager.updateDisabledTools(snapshot) }
+        }
+    }
+
+    func isToolEnabled(_ name: String) -> Bool {
+        !disabledTools.contains(name)
+    }
+
+    func setTool(_ name: String, enabled: Bool) {
+        var tools = disabledTools
+        if enabled {
+            tools.remove(name)
+        } else {
+            tools.insert(name)
+        }
+        disabledTools = tools
+    }
+
     // MARK: - Connection Approval Methods
     private func cleanupApprovalState() {
         pendingClientName = ""
@@ -265,6 +295,7 @@ final class ServerController: ObservableObject {
         Task {
             // Initialize bindings from AppStorage before the server starts.
             await networkManager.updateServiceBindings(self.currentServiceBindings)
+            await networkManager.updateDisabledTools(self.disabledTools)
             await self.networkManager.start()
             self.updateServerStatus("Running")
 
@@ -636,6 +667,7 @@ actor ServerNetworkManager {
 
     private let services = ServiceRegistry.services
     private var serviceBindings: [String: Binding<Bool>] = [:]
+    private var disabledTools: Set<String> = []
 
     init() {
         do {
@@ -880,6 +912,10 @@ actor ServerNetworkManager {
                         isServiceEnabled
                     {
                         for tool in service.tools {
+                            if await self.disabledTools.contains(tool.name) {
+                                log.debug("Skipping disabled tool: \(tool.name)")
+                                continue
+                            }
                             log.debug("Adding tool: \(tool.name)")
                             tools.append(
                                 .init(
@@ -914,6 +950,20 @@ actor ServerNetworkManager {
                     content: [
                         .text(
                             text: "iMCP is currently disabled. Please enable it to use tools.",
+                            annotations: nil,
+                            _meta: nil
+                        )
+                    ],
+                    isError: true
+                )
+            }
+
+            if await self.disabledTools.contains(params.name) {
+                log.notice("Tool call rejected: \(params.name) is disabled")
+                return CallTool.Result(
+                    content: [
+                        .text(
+                            text: "Tool \(params.name) is currently disabled in iMCP settings.",
                             annotations: nil,
                             _meta: nil
                         )
@@ -1020,6 +1070,19 @@ actor ServerNetworkManager {
     // Update service bindings.
     func updateServiceBindings(_ newBindings: [String: Binding<Bool>]) async {
         self.serviceBindings = newBindings
+
+        // Notify clients that tool availability may have changed.
+        Task {
+            for (_, connectionManager) in connections {
+                await connectionManager.notifyToolListChanged()
+            }
+        }
+    }
+
+    // Update the disabled tool set.
+    func updateDisabledTools(_ newDisabledTools: Set<String>) async {
+        guard disabledTools != newDisabledTools else { return }
+        self.disabledTools = newDisabledTools
 
         // Notify clients that tool availability may have changed.
         Task {

--- a/App/Views/ServiceToggleView.swift
+++ b/App/Views/ServiceToggleView.swift
@@ -41,6 +41,7 @@ struct ServiceToggleView: View {
             .buttonStyle(PlainButtonStyle())
             .disabled(!isEnabled)
             .frame(width: buttonSize, height: buttonSize)
+            .help("\(config.name) tools: \(toolSummary)")
 
             Text(config.name)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -68,5 +69,11 @@ struct ServiceToggleView: View {
         } else {
             return .primary.opacity(isEnabled ? 0.7 : 0.4)
         }
+    }
+
+    private var toolSummary: String {
+        config.service.tools
+            .map { $0.annotations.title ?? $0.name }
+            .joined(separator: ", ")
     }
 }

--- a/App/Views/ServicesSettingsView.swift
+++ b/App/Views/ServicesSettingsView.swift
@@ -28,10 +28,11 @@ struct ServicesSettingsView: View {
 
                         Spacer()
 
-                        Toggle("", isOn: serviceBinding(config))
+                        Toggle(config.name, isOn: serviceBinding(config))
                             .toggleStyle(.switch)
                             .controlSize(.small)
                             .labelsHidden()
+                            .id("\(config.id)-\(config.binding.wrappedValue)")
                     }
                 }
             }
@@ -64,12 +65,12 @@ struct ServicesSettingsView: View {
 
             Spacer()
 
-            Toggle("", isOn: toolBinding(tool.name))
+            Toggle(tool.annotations.title ?? tool.name, isOn: toolBinding(tool.name))
                 .toggleStyle(.switch)
                 .controlSize(.mini)
                 .labelsHidden()
+                .id("\(tool.name)-\(serverController.isToolEnabled(tool.name))")
         }
-        .accessibilityElement(children: .combine)
     }
 
     // Route writes through ServerController so views observing it refresh;

--- a/App/Views/ServicesSettingsView.swift
+++ b/App/Views/ServicesSettingsView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct ServicesSettingsView: View {
+    @ObservedObject var serverController: ServerController
+
+    var body: some View {
+        Form {
+            ForEach(serverController.computedServiceConfigs) { config in
+                Section {
+                    ForEach(config.service.tools, id: \.name) { tool in
+                        toolRow(tool)
+                    }
+                    .disabled(!config.binding.wrappedValue)
+                } header: {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(config.color)
+                            .overlay(
+                                Image(systemName: config.iconName)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .foregroundColor(.white)
+                                    .padding(4)
+                            )
+                            .frame(width: 20, height: 20)
+
+                        Text(config.name)
+
+                        Spacer()
+
+                        Toggle("", isOn: serviceBinding(config))
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                            .labelsHidden()
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private func toolRow(_ tool: Tool) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(tool.annotations.title ?? tool.name)
+
+                    if tool.annotations.readOnlyHint == true {
+                        Text("Read-only")
+                            .font(.caption2)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.secondary.opacity(0.15)))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Text(tool.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: toolBinding(tool.name))
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // Route writes through ServerController so views observing it refresh;
+    // @AppStorage-backed bindings don't publish through ObservableObject alone.
+    private func serviceBinding(_ config: ServiceConfig) -> Binding<Bool> {
+        Binding(
+            get: { config.binding.wrappedValue },
+            set: { newValue in
+                serverController.objectWillChange.send()
+                config.binding.wrappedValue = newValue
+            }
+        )
+    }
+
+    private func toolBinding(_ name: String) -> Binding<Bool> {
+        Binding(
+            get: { serverController.isToolEnabled(name) },
+            set: { serverController.setTool(name, enabled: $0) }
+        )
+    }
+}

--- a/App/Views/ServicesSettingsView.swift
+++ b/App/Views/ServicesSettingsView.swift
@@ -73,15 +73,12 @@ struct ServicesSettingsView: View {
         }
     }
 
-    // Route writes through ServerController so views observing it refresh;
-    // @AppStorage-backed bindings don't publish through ObservableObject alone.
+    // Delegate to ServerController so toggling activates the service (permission
+    // prompt, revert on failure) and pushes updated bindings to connected clients.
     private func serviceBinding(_ config: ServiceConfig) -> Binding<Bool> {
         Binding(
             get: { config.binding.wrappedValue },
-            set: { newValue in
-                serverController.objectWillChange.send()
-                config.binding.wrappedValue = newValue
-            }
+            set: { serverController.setService(config, enabled: $0) }
         )
     }
 

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -6,12 +6,14 @@ struct SettingsView: View {
 
     enum SettingsSection: String, CaseIterable, Identifiable {
         case general = "General"
+        case services = "Services"
 
         var id: String { self.rawValue }
 
         var icon: String {
             switch self {
             case .general: return "gear"
+            case .services: return "square.grid.2x2"
             }
         }
     }
@@ -40,6 +42,9 @@ struct SettingsView: View {
                     GeneralSettingsView(serverController: serverController)
                         .navigationTitle("General")
                         .formStyle(.grouped)
+                case .services:
+                    ServicesSettingsView(serverController: serverController)
+                        .navigationTitle("Services")
                 }
             } else {
                 Text("Select a category")


### PR DESCRIPTION
## Summary

Enabling a service is all-or-nothing, and nothing in the UI says what it grants. Toggling Calendar on exposes event creation as well as reading — the user can't see that, and can't allow one without the other. For an app whose job is handing personal data to AI clients, that's too coarse.

This adds per-tool control, enforced by the server:

- **Server enforcement.** A persisted set of disabled tool names filters `tools/list` and rejects `tools/call` — a client holding a stale list still can't invoke a disabled tool. Changes push to connected clients via `tools/listChanged`. Updates to the network actor carry a generation counter so out-of-order delivery can't apply a stale set.
- **Settings → Services.** New pane listing every service's tools with title, description, a Read-only badge (from tool annotations), and a switch per tool. Service master toggles here go through activation, so enabling from Settings triggers the macOS permission prompt and reverts if denied — same as the menu.
- **Menu tooltips.** Hovering a service row lists its tools by name.

Default state (nothing disabled) serves the identical tool list as before.

Conflicts with #183 on one tooltip line in `ServiceToggleView` — trivial to resolve whichever lands second.

## Test plan

- [x] End-to-end over MCP stdio: baseline 19 tools → disable `calendars_list` → absent from `tools/list`, `tools/call` returns the disabled error → persists across relaunch → restore returns the baseline byte-identical
- [x] Settings pane renders all services/tools with badges and switches; rows dim when the service is off; per-tool state survives service off/on
- [x] `xcodebuild build` succeeds
- [ ] Not verified: a `tools/list` refresh in a live Claude Desktop session at the moment a switch is clicked

## Known issue

Freshly rendered switch rows in the pane can transiently paint the wrong position (state is never wrong, repaint corrects it). Mitigated with value-keyed identity; the full fix is moving the disabled set to a published property, which I kept out of scope here.