### PR TITLE
Bump Madrid to 0.4.0

### DIFF
--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -717,7 +717,7 @@
 			repositoryURL = "https://github.com/loopwork-ai/madrid";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.4.0;
 			};
 		};
 		F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */ = {

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/loopwork-ai/madrid",
       "state" : {
-        "revision" : "9d9fdb20424483fb592e5a026d9d0816cd5c43eb",
-        "version" : "0.1.0"
+        "revision" : "8f5f4f1eb87e3180e5572e72885d0eb6ea7bc13b",
+        "version" : "0.4.0"
       }
     },
     {


### PR DESCRIPTION
iMCP is pinned to Madrid 0.1.0; 0.4.0 is current. This bumps the pin with no behaviour change, so later work can use `Message.readAt` / `isRead`, added in 0.3.0 for #154.

The requirement was already `upToNextMajorVersion` from 0.1.0, which 0.4.0 satisfies, so this is a re-resolve. The declared minimum is raised alongside the lockfile so the two agree.

**Source compatibility.** iMCP's whole Madrid surface is five call sites in `Messages.swift`: `Database()`, `Database(path:)`, `fetchParticipant(matching:)`, `fetchMessages(with:in:limit:)`, and the `Message` properties `messages_fetch` reads. All still compile — I built them against 0.4.0 rather than reading the diff. `Message`'s memberwise init gained `readAt`, but iMCP never constructs one.

**Behaviour.** Two cases could have differed; both match 0.1.0. With empty participants, the 0.4.0 shim omits the predicate and `.and([])` compiles to an absent `WHERE` rather than a false one. Ordering was `m.date DESC` and is now `[.date(.descending), .id(.descending)]` — same order, added tiebreak.

**One wrinkle.** This introduces a deprecation warning, since `fetchMessages(for:with:in:limit:)` is superseded by `fetch(_:)`. I left it to keep this a pure bump, but the migration is behaviour-identical to the shim if you'd rather have it here:

```swift
var predicates: [MessagePredicate] = []
if !handles.isEmpty { predicates.append(.participantHandles(Set(handles))) }
if let dateRange { predicates.append(.dateRange(dateRange)) }

for message in try db.fetch(
    MessageFetchRequest(predicate: .and(predicates), limit: max(limit ?? defaultLimit, 1024))
) {
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)