### PR TITLE
Fix Bonjour browser cleanup on discovery timeout (DNS leak issue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,44 @@ playground.xcworkspace
 
 # Release artifacts
 dist/
+imcp-derived-release/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Xcode build artifacts
+DerivedData/
+build/
+*.xcresult
+*.xcarchive
+
+# Xcode source control state (per-user)
+*.xccheckout
+*.xcscmblueprint
+*.xcuserstate
+
+# Local env files (secrets)
+.env
+.env.*
+!.env.example
+!.env.sample
+
+# General temp / logs
+*.log
+*.tmp
+*.bak
+*.swp
+*.swo
+*~
+
+# IDEs
+.idea/
+*.iml
+.vscode/*
+!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
+!.vscode/extensions.json
+*.code-workspace

--- a/App/App.entitlements
+++ b/App/App.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.weatherkit</key>
-	<true/>
 	<key>com.apple.security.inherit</key>
 	<true/>
 	<key>com.apple.security.personal-information.health</key>

--- a/App/Extensions/EventKit+Extensions.swift
+++ b/App/Extensions/EventKit+Extensions.swift
@@ -38,6 +38,30 @@ extension EKEventStatus {
     }
 }
 
+extension EKEvent {
+    /// Whether the current user organizes/owns this event, as opposed to having
+    /// been invited to it by someone else.
+    ///
+    /// An event with no organizer (e.g. a plain event you created, a birthday, or
+    /// a subscribed holiday) is treated as your own. An event that has an organizer
+    /// is yours only if that organizer is the current user; otherwise it was created
+    /// by someone else and shared/invited to you (e.g. a colleague's leave).
+    var isOrganizedByCurrentUser: Bool {
+        guard let organizer = organizer else { return true }
+        return organizer.isCurrentUser
+    }
+
+    /// Display name of the organizer, if the event was organized by someone else.
+    /// Returns `nil` for events you own or when no organizer information is available.
+    var organizerDisplayName: String? {
+        guard let organizer = organizer, !organizer.isCurrentUser else { return nil }
+        return organizer.name ?? organizer.url.absoluteString.replacingOccurrences(
+            of: "mailto:",
+            with: ""
+        )
+    }
+}
+
 extension EKRecurrenceFrequency {
     init(_ string: String) {
         switch string.lowercased() {

--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -94,6 +94,11 @@ final class CalendarService: Service {
                     ),
                     "hasAlarms": .boolean(),
                     "isRecurring": .boolean(),
+                    "organizer": .string(
+                        description:
+                            "Filter by who organized the event: 'me' for events you created or organize (including personal events with no other participants, birthdays, and subscribed holidays), 'others' for events someone else invited you to (e.g. a colleague's shared vacation/leave). Omit to include both.",
+                        enum: ["me", "others"]
+                    ),
                 ],
                 additionalProperties: false
             ),
@@ -216,7 +221,36 @@ final class CalendarService: Service {
                 events = events.filter { ($0.hasRecurrenceRules) == isRecurring }
             }
 
-            return events.map { Event($0) }
+            if case .string(let organizer) = arguments["organizer"] {
+                switch organizer {
+                case "me":
+                    events = events.filter { $0.isOrganizedByCurrentUser }
+                case "others":
+                    events = events.filter { !$0.isOrganizedByCurrentUser }
+                default:
+                    break
+                }
+            }
+
+            // Encode each event and annotate it with organizer information so callers
+            // can distinguish events the user owns from ones they were invited to.
+            let encoder = JSONEncoder()
+            encoder.userInfo[Ontology.DateTime.timeZoneOverrideKey] = TimeZone.current
+            encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+            let decoder = JSONDecoder()
+
+            return try events.map { ekEvent -> Value in
+                let data = try encoder.encode(Event(ekEvent))
+                var value = try decoder.decode(Value.self, from: data)
+                if case .object(var object) = value {
+                    object["organizedByMe"] = .bool(ekEvent.isOrganizedByCurrentUser)
+                    if let organizerName = ekEvent.organizerDisplayName {
+                        object["organizer"] = .string(organizerName)
+                    }
+                    value = .object(object)
+                }
+                return value
+            }
         }
         Tool(
             name: "events_create",

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -129,6 +129,44 @@ final class ContactsService: Service {
         }
     }
 
+    /// Resolve a saved place name — "home", "work", or any custom label on the
+    /// user's "Me" contact card — to its postal address. Returns `nil` if no
+    /// postal address on the Me card matches the given name.
+    func savedPostalAddress(named name: String) async throws -> CNPostalAddress? {
+        let target = name.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !target.isEmpty else { return nil }
+
+        try await activate()
+
+        let contact = try await runContactStore {
+            try self.contactStore.unifiedMeContactWithKeys(toFetch: contactKeys)
+        }
+
+        // Map common English names to Apple's label constants so "home"/"work"
+        // resolve regardless of the system locale (localizedString would return
+        // e.g. "thuis"/"werk" under a Dutch locale).
+        let canonicalLabels: [String] = {
+            switch target {
+            case "home": return [CNLabelHome]
+            case "work": return [CNLabelWork]
+            default: return []
+            }
+        }()
+
+        for labeled in contact.postalAddresses {
+            guard let label = labeled.label else { continue }
+            let localized = CNLabeledValue<NSString>.localizedString(forLabel: label)
+            if canonicalLabels.contains(label)
+                || localized.lowercased() == target
+                || label.lowercased() == target
+            {
+                return labeled.value
+            }
+        }
+
+        return nil
+    }
+
     var tools: [Tool] {
         Tool(
             name: "contacts_me",

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -1,3 +1,5 @@
+import Contacts
+import CoreLocation
 import EventKit
 import Foundation
 import OSLog
@@ -18,6 +20,159 @@ final class RemindersService: Service {
 
     func activate() async throws {
         try await eventStore.requestFullAccessToReminders()
+    }
+
+    /// Build a location-based proximity `EKAlarm` from a `location` argument
+    /// object. Coordinates come from explicit latitude/longitude, or by
+    /// resolving `address` — first as a saved place ("home"/"work"/custom
+    /// label) on the user's contact card, then as a free-form address.
+    private func makeLocationAlarm(from location: [String: Value]) async throws -> EKAlarm {
+        var coordinate: CLLocationCoordinate2D? = nil
+        var locationTitle = location["title"]?.stringValue
+
+        if let latitude = location["latitude"]?.doubleValue,
+            let longitude = location["longitude"]?.doubleValue
+        {
+            coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        } else if case .string(let address) = location["address"], !address.isEmpty {
+            let geocoder = CLGeocoder()
+
+            let savedAddress = try? await ContactsService.shared.savedPostalAddress(
+                named: address
+            )
+
+            let placemarks: [CLPlacemark]
+            if let savedAddress {
+                placemarks = try await geocoder.geocodePostalAddress(savedAddress)
+                if locationTitle == nil {
+                    locationTitle = address.capitalized
+                }
+            } else {
+                placemarks = try await geocoder.geocodeAddressString(address)
+            }
+
+            guard let placemark = placemarks.first,
+                let geoLocation = placemark.location
+            else {
+                throw NSError(
+                    domain: "RemindersError",
+                    code: 3,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Could not resolve location: \(address)"
+                    ]
+                )
+            }
+            coordinate = geoLocation.coordinate
+            if locationTitle == nil {
+                locationTitle = placemark.name ?? address
+            }
+        }
+
+        guard let resolvedCoordinate = coordinate else {
+            throw NSError(
+                domain: "RemindersError",
+                code: 4,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Location trigger requires either an address or latitude/longitude"
+                ]
+            )
+        }
+
+        let structuredLocation = EKStructuredLocation(title: locationTitle ?? "Location")
+        structuredLocation.geoLocation = CLLocation(
+            latitude: resolvedCoordinate.latitude,
+            longitude: resolvedCoordinate.longitude
+        )
+        if let radius = location["radius"]?.doubleValue {
+            structuredLocation.radius = radius
+        }
+
+        log.notice(
+            "Reminder location trigger resolved to \(locationTitle ?? "Location", privacy: .public) at \(resolvedCoordinate.latitude, privacy: .private),\(resolvedCoordinate.longitude, privacy: .private)"
+        )
+
+        let locationAlarm = EKAlarm()
+        locationAlarm.structuredLocation = structuredLocation
+        locationAlarm.proximity =
+            location["proximity"]?.stringValue?.lowercased() == "leaving"
+            ? .leave : .enter
+        return locationAlarm
+    }
+
+    /// Fetch reminders, optionally restricted to a single list by name.
+    private func fetchReminders(inListNamed listName: String?) async throws -> [EKReminder] {
+        var lists = self.eventStore.calendars(for: .reminder)
+        if let listName {
+            lists = lists.filter { $0.title.lowercased() == listName.lowercased() }
+        }
+        let predicate = self.eventStore.predicateForReminders(in: lists)
+        return try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<[EKReminder], Error>) in
+            self.eventStore.fetchReminders(matching: predicate) { reminders in
+                continuation.resume(returning: reminders ?? [])
+            }
+        }
+    }
+
+    /// Locate a single reminder by its stable identifier (preferred), or by an
+    /// exact case-insensitive title match (optionally restricted to a list).
+    /// Throws if nothing matches, or if a title matches more than one reminder.
+    private func locateReminder(
+        identifier: String?,
+        title: String?,
+        listName: String?
+    ) async throws -> EKReminder {
+        if let identifier, !identifier.isEmpty {
+            guard
+                let reminder = self.eventStore.calendarItem(withIdentifier: identifier)
+                    as? EKReminder
+            else {
+                throw NSError(
+                    domain: "RemindersError",
+                    code: 5,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "No reminder found with identifier: \(identifier)"
+                    ]
+                )
+            }
+            return reminder
+        }
+
+        guard let title, !title.isEmpty else {
+            throw NSError(
+                domain: "RemindersError",
+                code: 6,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Provide an identifier or a title to locate the reminder"
+                ]
+            )
+        }
+
+        let matches = try await self.fetchReminders(inListNamed: listName).filter {
+            $0.title?.lowercased() == title.lowercased()
+        }
+
+        guard let first = matches.first else {
+            throw NSError(
+                domain: "RemindersError",
+                code: 7,
+                userInfo: [NSLocalizedDescriptionKey: "No reminder found with title: \(title)"]
+            )
+        }
+        guard matches.count == 1 else {
+            throw NSError(
+                domain: "RemindersError",
+                code: 8,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Found \(matches.count) reminders titled \"\(title)\"; pass an identifier (from reminders_fetch) to choose one"
+                ]
+            )
+        }
+        return first
     }
 
     var tools: [Tool] {
@@ -190,12 +345,17 @@ final class RemindersService: Service {
                 }
             }
 
-            return filteredReminders.map { PlanAction($0) }
+            return filteredReminders.map { reminder -> PlanAction in
+                var action = PlanAction(reminder)
+                action.identifier = reminder.calendarItemIdentifier
+                return action
+            }
         }
 
         Tool(
             name: "reminders_create",
-            description: "Create a new reminder with specified properties",
+            description:
+                "Create a new reminder with specified properties, including an optional location-based trigger that fires when arriving at or leaving a place (e.g. \"when I arrive home\")",
             inputSchema: .object(
                 properties: [
                     "title": .string(),
@@ -215,6 +375,36 @@ final class RemindersService: Service {
                     "alarms": .array(
                         description: "Minutes before due date to set alarms",
                         items: .integer()
+                    ),
+                    "location": .object(
+                        description:
+                            "Location-based trigger that fires when arriving at or leaving a place. Provide either an address to geocode, or explicit latitude/longitude coordinates.",
+                        properties: [
+                            "address": .string(
+                                description:
+                                    "Address to geocode, or a saved place name from the user's contact card such as \"home\" or \"work\" (use this or latitude/longitude)"
+                            ),
+                            "latitude": .number(
+                                description: "Latitude, used together with longitude"
+                            ),
+                            "longitude": .number(
+                                description: "Longitude, used together with latitude"
+                            ),
+                            "radius": .number(
+                                description: "Trigger radius in meters",
+                                default: .double(100)
+                            ),
+                            "proximity": .string(
+                                description:
+                                    "Whether the reminder fires when arriving at or leaving the location",
+                                default: .string("arriving"),
+                                enum: [.string("arriving"), .string("leaving")]
+                            ),
+                            "title": .string(
+                                description: "Display name for the location (e.g. \"Home\")"
+                            ),
+                        ],
+                        additionalProperties: false
                     ),
                 ],
                 required: ["title"],
@@ -293,10 +483,236 @@ final class RemindersService: Service {
                 }
             }
 
+            // Set location-based trigger (proximity alarm)
+            if case .object(let location) = arguments["location"] {
+                reminder.addAlarm(try await self.makeLocationAlarm(from: location))
+            }
+
             // Save the reminder
             try self.eventStore.save(reminder, commit: true)
 
-            return PlanAction(reminder)
+            var action = PlanAction(reminder)
+            action.identifier = reminder.calendarItemIdentifier
+            return action
+        }
+
+        Tool(
+            name: "reminders_update",
+            description:
+                "Update an existing reminder. Locate it by \"identifier\" (from reminders_fetch, recommended) or by \"title\". Only provide the properties you want to change; omitted properties are left unchanged. When locating by identifier, passing \"title\" renames the reminder.",
+            inputSchema: .object(
+                properties: [
+                    "identifier": .string(
+                        description:
+                            "Stable identifier of the reminder to update (from reminders_fetch). Preferred over title."
+                    ),
+                    "title": .string(
+                        description:
+                            "If \"identifier\" is omitted, the exact title used to locate the reminder. If \"identifier\" is provided, the new title to rename it to."
+                    ),
+                    "due": .string(
+                        description:
+                            "New due date/time. If timezone is omitted, local time is assumed. Date-only uses local midnight.",
+                        format: .dateTime
+                    ),
+                    "list": .string(
+                        description: "Move the reminder to this list"
+                    ),
+                    "notes": .string(),
+                    "completed": .boolean(
+                        description: "Mark the reminder complete (true) or incomplete (false)"
+                    ),
+                    "priority": .string(
+                        enum: EKReminderPriority.allCases.map { .string($0.stringValue) }
+                    ),
+                    "alarms": .array(
+                        description:
+                            "Replace time-based alarms with these (minutes before due date). Location triggers are preserved.",
+                        items: .integer()
+                    ),
+                    "location": .object(
+                        description:
+                            "Replace the location-based trigger. Provide either an address to geocode (incl. saved places like \"home\"/\"work\"), or explicit latitude/longitude coordinates.",
+                        properties: [
+                            "address": .string(
+                                description:
+                                    "Address to geocode, or a saved place name from the user's contact card such as \"home\" or \"work\" (use this or latitude/longitude)"
+                            ),
+                            "latitude": .number(
+                                description: "Latitude, used together with longitude"
+                            ),
+                            "longitude": .number(
+                                description: "Longitude, used together with latitude"
+                            ),
+                            "radius": .number(
+                                description: "Trigger radius in meters",
+                                default: .double(100)
+                            ),
+                            "proximity": .string(
+                                description:
+                                    "Whether the reminder fires when arriving at or leaving the location",
+                                default: .string("arriving"),
+                                enum: [.string("arriving"), .string("leaving")]
+                            ),
+                            "title": .string(
+                                description: "Display name for the location (e.g. \"Home\")"
+                            ),
+                        ],
+                        additionalProperties: false
+                    ),
+                ],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Update Reminder",
+                destructiveHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            let identifier = arguments["identifier"]?.stringValue
+            let titleArg = arguments["title"]?.stringValue
+
+            let reminder = try await self.locateReminder(
+                identifier: identifier,
+                title: (identifier == nil) ? titleArg : nil,
+                listName: nil
+            )
+
+            // When located by identifier, a title argument renames the reminder
+            if identifier != nil, let newTitle = titleArg, !newTitle.isEmpty {
+                reminder.title = newTitle
+            }
+
+            // Move to another list
+            if case .string(let listName) = arguments["list"],
+                let matchingCalendar = self.eventStore.calendars(for: .reminder)
+                    .first(where: { $0.title.lowercased() == listName.lowercased() })
+            {
+                reminder.calendar = matchingCalendar
+            }
+
+            if case .string(let dueDateStr) = arguments["due"],
+                let parsedDueDate = ISO8601DateFormatter.parsedLenientISO8601Date(
+                    fromISO8601String: dueDateStr
+                )
+            {
+                let calendar = Calendar.current
+                let dueDate = calendar.normalizedStartDate(
+                    from: parsedDueDate.date,
+                    isDateOnly: parsedDueDate.isDateOnly
+                )
+                reminder.dueDateComponents = calendar.dateComponents(
+                    [.year, .month, .day, .hour, .minute, .second],
+                    from: dueDate
+                )
+            }
+
+            if case .string(let notes) = arguments["notes"] {
+                reminder.notes = notes
+            }
+
+            if case .bool(let completed) = arguments["completed"] {
+                reminder.isCompleted = completed
+            }
+
+            if case .string(let priorityStr) = arguments["priority"] {
+                reminder.priority = Int(EKReminderPriority.from(string: priorityStr).rawValue)
+            }
+
+            // Replace time-based alarms, preserving any location triggers
+            if case .array(let alarmMinutes) = arguments["alarms"] {
+                let locationAlarms = (reminder.alarms ?? []).filter {
+                    $0.structuredLocation != nil
+                }
+                let timeAlarms = alarmMinutes.compactMap { value -> EKAlarm? in
+                    guard case .int(let minutes) = value else { return nil }
+                    return EKAlarm(relativeOffset: TimeInterval(-minutes * 60))
+                }
+                reminder.alarms = locationAlarms + timeAlarms
+            }
+
+            // Replace the location trigger, preserving any time-based alarms
+            if case .object(let location) = arguments["location"] {
+                let nonLocationAlarms = (reminder.alarms ?? []).filter {
+                    $0.structuredLocation == nil
+                }
+                let locationAlarm = try await self.makeLocationAlarm(from: location)
+                reminder.alarms = nonLocationAlarms + [locationAlarm]
+            }
+
+            try self.eventStore.save(reminder, commit: true)
+
+            var action = PlanAction(reminder)
+            action.identifier = reminder.calendarItemIdentifier
+            return action
+        }
+
+        Tool(
+            name: "reminders_delete",
+            description:
+                "Delete a reminder. Locate it by \"identifier\" (from reminders_fetch, recommended) or by \"title\". If a title matches more than one reminder, an identifier is required.",
+            inputSchema: .object(
+                properties: [
+                    "identifier": .string(
+                        description:
+                            "Stable identifier of the reminder to delete (from reminders_fetch). Preferred over title."
+                    ),
+                    "title": .string(
+                        description: "Exact title of the reminder to delete (if identifier omitted)"
+                    ),
+                    "list": .string(
+                        description: "Restrict a title match to this list"
+                    ),
+                ],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Delete Reminder",
+                destructiveHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            let reminder = try await self.locateReminder(
+                identifier: arguments["identifier"]?.stringValue,
+                title: arguments["title"]?.stringValue,
+                listName: arguments["list"]?.stringValue
+            )
+
+            // Capture details before removal
+            let deletedIdentifier = reminder.calendarItemIdentifier
+            let deletedTitle = reminder.title ?? ""
+            let listTitle = reminder.calendar?.title ?? ""
+
+            try self.eventStore.remove(reminder, commit: true)
+
+            return Value.object([
+                "deleted": .bool(true),
+                "identifier": .string(deletedIdentifier),
+                "title": .string(deletedTitle),
+                "list": .string(listTitle),
+            ])
         }
     }
 }

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -498,6 +498,7 @@ actor MCPService: Service {
                         // If we haven't found a service by now, resume with an error
                         if await connectionState.checkAndSetResumed() {
                             await log.error("Bonjour service discovery timed out after 30 seconds")
+                            browser.cancel()
                             continuation.resume(
                                 throwing: MCPError.internalError("Service discovery timeout")
                             )


### PR DESCRIPTION
Fix Bonjour browser cleanup on discovery timeout
Cancel the NWBrowser before resuming the timeout error path so repeated discovery retries do not leave browse/connection handles open.