### PR TITLE
messages_fetch: report the conversation each message belongs to

### DIFF
--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -51,7 +51,8 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
     var tools: [Tool] {
         Tool(
             name: "messages_fetch",
-            description: "Fetch messages from the Messages app",
+            description:
+                "Fetch messages from the Messages app. Each message names the conversation it belongs to (isPartOf), with its participants.",
             inputSchema: .object(
                 properties: [
                     "participants": .array(
@@ -145,6 +146,10 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                 predicate: .and(predicates),
                 limit: max(limit ?? defaultLimit, 1024)
             )
+
+            // Each chat is looked up once and shared by all of its messages.
+            var conversations: [Chat.ID: [String: Value]] = [:]
+
             for message in try db.fetch(request) {
                 guard messages.count < (limit ?? defaultLimit) else { break }
                 guard !message.text.isEmpty else { continue }
@@ -185,6 +190,13 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                     object["dateRead"] = .string(readAt.formatted(.iso8601))
                 }
 
+                if let chatID = message.chatID {
+                    if conversations[chatID] == nil {
+                        conversations[chatID] = try self.conversation(for: chatID, in: db)
+                    }
+                    object["isPartOf"] = conversations[chatID].map { .object($0) }
+                }
+
                 messages.append(object)
             }
 
@@ -195,6 +207,30 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
                 "hasPart": Value.array(messages.map({ .object($0) })),
             ]
         }
+    }
+
+    /// Describes the chat a message belongs to:
+    /// its identifier, its display name (group chats) and its participants.
+    private func conversation(
+        for chatID: Chat.ID,
+        in db: iMessage.Database
+    ) throws -> [String: Value] {
+        var conversation: [String: Value] = [
+            "@type": "Conversation",
+            "@id": .string(chatID.rawValue),
+        ]
+
+        let request = FetchRequest<Chat>(predicate: .id(chatID), limit: 1)
+        if let chat = try db.fetch(request).first {
+            if let name = chat.displayName, !name.isEmpty {
+                conversation["name"] = .string(name)
+            }
+            conversation["participant"] = .array(
+                chat.participants.map { .object(["@id": .string($0.rawValue)]) }
+            )
+        }
+
+        return conversation
     }
 
     private var canAccessDatabaseAtDefaultPath: Bool {


### PR DESCRIPTION
Depends on Madrid 0.5.0 (mattt/Madrid#18), which `main` pins since #201. Rebased onto `main` on 2026-09-03: the branch no longer touches the package pin, and the change sits on top of the `FetchRequest<Message>` adoption and the `isRead` output.

## Problem

Messages you send from another device (iPhone, iPad) are synced to `chat.db` without a sender handle (`message.handle_id = 0`). Today `messages_fetch` returns them as `sender: "me"` with nothing that ties them to a conversation, so a client cannot tell who they were sent to, cannot thread them, and cannot even filter for them by `participants` (on my database that is 1 660 of my 2 610 messages over six months — everything typed on the phone). Group messages have the same problem: an inbound group message looks exactly like a 1:1 message from that person.

## Change

Each message now names the conversation it belongs to, as a schema.org `isPartOf`:

```json
{
  "@id": "8B9C…",
  "sender": { "@id": "me" },
  "text": "On my way",
  "createdAt": "2026-09-01T17:02:03Z",
  "isRead": true,
  "isPartOf": {
    "@type": "Conversation",
    "@id": "iMessage;-;+18002752273",
    "participant": [ { "@id": "+18002752273" } ]
  }
}
```

- `@id` is the chat GUID (`iMessage;-;<handle>` for a 1:1, `iMessage;+;chat…` for a group); `name` is present for named group chats; `participant` lists the other parties' handles.
- Chats are looked up once per call and shared by all of their messages (`FetchRequest<Chat>` with `ChatPredicate.id`), so the extra cost is one small query per distinct conversation.
- A message with no `chat_message_join` row (rare) simply has no `isPartOf`.
- Since Madrid 0.5.0, `participants: [handle]` also returns the messages *you* sent in chats that include that handle, which is what a caller asking for a conversation with someone expects; `isPartOf` is what lets the caller thread those messages.
- Tool description updated; the top-level shape (`@context`, `@type: Conversation`, `hasPart`) is unchanged, so existing clients keep working.

## Checks

- `swift format lint --strict --recursive App CLI` clean.
- Debug build (ad-hoc signed locally, Xcode 26.6) of the rebased branch compiles against Madrid 0.5.0.
- The pre-rebase build of this change ran for two days against a real `chat.db` behind a sync client: every message that has a chat carries `isPartOf`, phone-sent messages included.
