### PR TITLE
Cancel the Bonjour browser on every discovery exit path

### DIFF
--- a/CLI/BonjourDiscovery.swift
+++ b/CLI/BonjourDiscovery.swift
@@ -1,0 +1,73 @@
+import Network
+
+/// Guards a continuation so it is resumed exactly once.
+actor ConnectionState {
+    private var hasResumed = false
+
+    func checkAndSetResumed() -> Bool {
+        if !hasResumed {
+            hasResumed = true
+            return true
+        }
+        return false
+    }
+}
+
+/// Finds a Bonjour endpoint with a browser,
+/// and guarantees the browser is cancelled afterwards.
+///
+/// Every `NWBrowser` that has been started holds a `DNSServiceBrowse` connection
+/// to `mDNSResponder` until it is cancelled.
+/// `imcp-server` retries discovery in a loop,
+/// so a browser left running on any exit path leaks one connection per attempt (#192).
+enum BonjourDiscovery {
+    enum Error: Swift.Error {
+        case timeout
+    }
+
+    /// Starts `browser` on the main queue
+    /// and returns the first result that satisfies `preferring`,
+    /// or the first result at all if none does.
+    ///
+    /// The browser is cancelled before this function returns or throws,
+    /// whether a result was found, the browser failed, or `timeout` elapsed.
+    static func discoverEndpoint(
+        using browser: NWBrowser,
+        timeout: Duration,
+        preferring isPreferred: @escaping @Sendable (NWBrowser.Result) -> Bool
+    ) async throws -> NWEndpoint {
+        defer { browser.cancel() }
+
+        let state = ConnectionState()
+        return try await withCheckedThrowingContinuation { continuation in
+            let timeoutTask = Task {
+                try await Task.sleep(for: timeout)
+                if await state.checkAndSetResumed() {
+                    continuation.resume(throwing: Error.timeout)
+                }
+            }
+
+            browser.stateUpdateHandler = { browserState in
+                guard case .failed(let error) = browserState else { return }
+                Task {
+                    if await state.checkAndSetResumed() {
+                        timeoutTask.cancel()
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+
+            browser.browseResultsChangedHandler = { results, _ in
+                guard let selected = results.first(where: isPreferred) ?? results.first else { return }
+                Task {
+                    if await state.checkAndSetResumed() {
+                        timeoutTask.cancel()
+                        continuation.resume(returning: selected.endpoint)
+                    }
+                }
+            }
+
+            browser.start(queue: .main)
+        }
+    }
+}

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -24,25 +24,6 @@ if let tcpOptions = parameters.defaultProtocolStack.internetProtocol as? NWProto
     tcpOptions.version = .v4
 }
 
-// Create browser at top level
-let browser = NWBrowser(
-    for: .bonjour(type: serviceType, domain: nil),
-    using: parameters
-)
-log.info("Created Bonjour browser for service type: \(serviceType)")
-
-actor ConnectionState {
-    private var hasResumed = false
-
-    func checkAndSetResumed() -> Bool {
-        if !hasResumed {
-            hasResumed = true
-            return true
-        }
-        return false
-    }
-}
-
 /// An actor that provides a configurable proxy between standard I/O and network connections
 actor StdioProxy {
     // Connection configuration
@@ -471,7 +452,6 @@ enum StdioProxyError: Swift.Error {
 
 // Create MCPService class to manage lifecycle
 actor MCPService: Service {
-    private var browser: NWBrowser?
     private var currentProxy: StdioProxy?
 
     func run() async throws {
@@ -483,95 +463,22 @@ actor MCPService: Service {
                     for: .bonjour(type: serviceType, domain: nil),
                     using: parameters
                 )
-                self.browser = browser
 
-                // Find and connect to iMCP app with improved reliability
-                let endpoint: NWEndpoint = try await withCheckedThrowingContinuation {
-                    continuation in
-                    let connectionState = ConnectionState()
-
-                    // Set up a timeout task to ensure we don't wait forever
-                    let timeoutTask = Task {
-                        // Allow 30 seconds to find the service
-                        try await Task.sleep(for: .seconds(30))
-
-                        // If we haven't found a service by now, resume with an error
-                        if await connectionState.checkAndSetResumed() {
-                            await log.error("Bonjour service discovery timed out after 30 seconds")
-                            continuation.resume(
-                                throwing: MCPError.internalError("Service discovery timeout")
-                            )
-                        }
-                    }
-
-                    // Convert async handlers to sync handlers
-                    browser.stateUpdateHandler = { state in
-                        Task {
-                            switch state {
-                            case .failed(let error):
-                                await log.error("Browser failed: \(error)")
-                                if await connectionState.checkAndSetResumed() {
-                                    timeoutTask.cancel()
-                                    browser.cancel()
-                                    continuation.resume(throwing: error)
-                                }
-                            case .ready:
-                                await log.info("Browser is ready and searching for services")
-                            case .waiting(let error):
-                                await log.warning("Browser is waiting: \(error)")
-                            default:
-                                await log.debug("Browser state changed: \(state)")
-                            }
-                        }
-                    }
-
-                    browser.browseResultsChangedHandler = { results, changes in
-                        Task {
-                            await log.debug("Found \(results.count) Bonjour services")
-
-                            // Log all discovered services for debugging
-                            for (index, result) in results.enumerated() {
-                                await log.debug("Service \(index + 1): \(result.endpoint)")
-                            }
-
-                            // If we have results, select the most appropriate one
-                            if !results.isEmpty {
-                                // First, try to find a service with "iMCP" in the endpoint description
-                                let imcpServices = results.filter {
-                                    String(describing: $0.endpoint).contains("iMCP")
-                                }
-
-                                let selectedService: NWBrowser.Result
-
-                                if !imcpServices.isEmpty {
-                                    // Prefer services with iMCP in the description
-                                    selectedService = imcpServices.first!
-                                    await log.info(
-                                        "Selected iMCP service: \(selectedService.endpoint)"
-                                    )
-                                } else {
-                                    // Fall back to the first available service
-                                    selectedService = results.first!
-                                    await log.info(
-                                        "No specific iMCP service found, using: \(selectedService.endpoint)"
-                                    )
-                                }
-
-                                if await connectionState.checkAndSetResumed() {
-                                    timeoutTask.cancel()
-                                    browser.cancel()
-                                    await log.info("Selected endpoint: \(selectedService.endpoint)")
-                                    continuation.resume(returning: selectedService.endpoint)
-                                }
-                            }
-                        }
-                    }
-
-                    Task {
-                        await log.info("Starting Bonjour browser to discover MCP services...")
-                    }
-                    browser.start(queue: .main)
+                // Prefer a service advertised as iMCP; fall back to any MCP service.
+                // The helper cancels the browser on every exit path,
+                // so a timed-out attempt doesn't leak a DNS-SD connection (#192).
+                let endpoint: NWEndpoint
+                do {
+                    endpoint = try await BonjourDiscovery.discoverEndpoint(
+                        using: browser,
+                        timeout: .seconds(30),
+                        preferring: { String(describing: $0.endpoint).contains("iMCP") }
+                    )
+                } catch BonjourDiscovery.Error.timeout {
+                    await log.error("Bonjour service discovery timed out after 30 seconds")
+                    throw MCPError.internalError("Service discovery timeout")
                 }
+                await log.info("Selected endpoint: \(endpoint)")
 
                 await log.info("Creating connection to endpoint...")
 

--- a/CLITests/BonjourDiscoveryTests.swift
+++ b/CLITests/BonjourDiscoveryTests.swift
@@ -1,0 +1,44 @@
+import Network
+import XCTest
+
+/// Regression tests for `BonjourDiscovery`.
+///
+/// `imcp-server` retries discovery in a loop.
+/// Every browser it starts must be cancelled before the next attempt,
+/// or each one keeps a `DNSServiceBrowse` connection to `mDNSResponder` open.
+/// Leaking one per attempt eventually exhausts the daemon's descriptors
+/// and breaks DNS for every process on the machine (#192).
+final class BonjourDiscoveryTests: XCTestCase {
+
+    /// A browser that times out without finding anything must be cancelled,
+    /// not left running.
+    func testTimedOutBrowserIsCancelled() async throws {
+        let browser = NWBrowser(
+            for: .bonjour(type: "_imcp-test-absent._tcp", domain: nil),
+            using: .tcp
+        )
+
+        do {
+            _ = try await BonjourDiscovery.discoverEndpoint(
+                using: browser,
+                timeout: .milliseconds(500),
+                preferring: { _ in true }
+            )
+            XCTFail("Expected discovery to time out")
+        } catch {
+            // Expected.
+        }
+
+        let cancelled = await waitForCancellation(of: browser)
+        XCTAssertTrue(cancelled, "Browser was left running after timeout")
+    }
+
+    /// Cancellation is reported asynchronously, so poll briefly for it.
+    private func waitForCancellation(of browser: NWBrowser, attempts: Int = 40) async -> Bool {
+        for _ in 0 ..< attempts {
+            if case .cancelled = browser.state { return true }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return false
+    }
+}

--- a/CLITests/BonjourDiscoveryTests.swift
+++ b/CLITests/BonjourDiscoveryTests.swift
@@ -13,8 +13,11 @@ final class BonjourDiscoveryTests: XCTestCase {
     /// A browser that times out without finding anything must be cancelled,
     /// not left running.
     func testTimedOutBrowserIsCancelled() async throws {
+        // Bonjour service names are limited to 15 characters,
+        // so keep this one valid; an invalid type fails the browser immediately
+        // instead of exercising the timeout path.
         let browser = NWBrowser(
-            for: .bonjour(type: "_imcp-test-absent._tcp", domain: nil),
+            for: .bonjour(type: "_imcp-absent._tcp", domain: nil),
             using: .tcp
         )
 
@@ -25,8 +28,10 @@ final class BonjourDiscoveryTests: XCTestCase {
                 preferring: { _ in true }
             )
             XCTFail("Expected discovery to time out")
+        } catch BonjourDiscovery.Error.timeout {
+            // Expected: nothing advertises this type, so only the timeout can end discovery.
         } catch {
-            // Expected.
+            XCTFail("Expected the timeout error, got \(error)")
         }
 
         let cancelled = await waitForCancellation(of: browser)

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		826C0834A5B647F8A918E54D /* ServiceLifecycle in Frameworks */ = {isa = PBXBuildFile; productRef = DCE061F8A68D0CD546D919E2 /* ServiceLifecycle */; };
 		8DFCE9E4CBCBEB93A32E8560 /* ServiceLifecycleTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1CD6B9E157EEC273F178543D /* ServiceLifecycleTestKit */; };
 		930214FCD680D7D74158F215 /* ServiceGroupConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */; };
+		B0D1DEADBEEF000000000002 /* BonjourDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1DEADBEEF000000000001 /* BonjourDiscovery.swift */; };
+		B0D1DEADBEEF000000000004 /* BonjourDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1DEADBEEF000000000003 /* BonjourDiscoveryTests.swift */; };
 		F809556E2D7888920055B911 /* TypedStream in Frameworks */ = {isa = PBXBuildFile; productRef = F809556D2D7888920055B911 /* TypedStream */; };
 		F80955702D7888920055B911 /* iMessage in Frameworks */ = {isa = PBXBuildFile; productRef = F809556F2D7888920055B911 /* iMessage */; };
 		F825BDBF2D9AD00E0063ADD7 /* ServiceLifecycle in Frameworks */ = {isa = PBXBuildFile; productRef = F825BDBE2D9AD00E0063ADD7 /* ServiceLifecycle */; };
@@ -54,6 +56,8 @@
 /* Begin PBXFileReference section */
 		6A5CFBBEC66BC8CDA9D65496 /* imcp-serverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "imcp-serverTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ServiceGroupConfigurationTests.swift; sourceTree = "<group>"; };
+		B0D1DEADBEEF000000000001 /* BonjourDiscovery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BonjourDiscovery.swift; path = ../CLI/BonjourDiscovery.swift; sourceTree = "<group>"; };
+		B0D1DEADBEEF000000000003 /* BonjourDiscoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BonjourDiscoveryTests.swift; sourceTree = "<group>"; };
 		E0E66768348853754D32208C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		F8F44E6D2D59038D0075D79C /* iMCP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iMCP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F44EB62D5908D00075D79C /* imcp-server */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "imcp-server"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +143,8 @@
 			isa = PBXGroup;
 			children = (
 				75E148EAC5AC8B3263C5AA13 /* ServiceGroupConfigurationTests.swift */,
+				B0D1DEADBEEF000000000003 /* BonjourDiscoveryTests.swift */,
+				B0D1DEADBEEF000000000001 /* BonjourDiscovery.swift */,
 			);
 			path = CLITests;
 			sourceTree = "<group>";
@@ -326,6 +332,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				930214FCD680D7D74158F215 /* ServiceGroupConfigurationTests.swift in Sources */,
+				B0D1DEADBEEF000000000004 /* BonjourDiscoveryTests.swift in Sources */,
+				B0D1DEADBEEF000000000002 /* BonjourDiscovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Fixes #192. Fixes #174.

`imcp-server` retries discovery in a loop, creating a new `NWBrowser` each time. The 30-second timeout path never cancelled the previous browser (only the found and failed paths did), so every timed-out attempt left a `DNSServiceBrowse` connection to `mDNSResponder` open. With the app not running, that leaked one connection every ~35 seconds, which matches the cadence in #192, until the daemon ran out of descriptors and DNS failed machine-wide.

Discovery now lives in `BonjourDiscovery.discoverEndpoint`, which cancels the browser in a `defer` on every exit. The file is compiled into the CLI test target too, so there's a regression test against a real `NWBrowser` that fails without the cancel. Also removes a module-level browser that was never started and a write-only property.
