### PR TITLE
Exempt connections awaiting approval from the setup timeout

### DIFF
--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -628,6 +628,10 @@ actor ServerNetworkManager {
     private var discoveryManager: NetworkDiscoveryManager?
     private var connections: [UUID: MCPConnectionManager] = [:]
     private var connectionTasks: [UUID: Task<Void, Never>] = [:]
+    /// Connections whose setup is waiting on the user's approval decision.
+    /// The setup timeout leaves these alone:
+    /// the person reading the dialog is not a stalled handshake.
+    private var connectionsAwaitingApproval: Set<UUID> = []
     private var pendingConnections: [UUID: String] = [:]
     private var removedConnections: Set<UUID> = []
 
@@ -824,7 +828,11 @@ actor ServerNetworkManager {
                 }
 
                 try await connectionManager.start { clientInfo in
-                    await approvalHandler(connectionID, clientInfo)
+                    // From here the wait is on a person, not the client,
+                    // so exempt the connection from the setup timeout (#193).
+                    self.connectionsAwaitingApproval.insert(connectionID)
+                    defer { self.connectionsAwaitingApproval.remove(connectionID) }
+                    return await approvalHandler(connectionID, clientInfo)
                 }
 
                 log.notice("Connection \(connectionID) successfully established")
@@ -840,9 +848,11 @@ actor ServerNetworkManager {
         Task {
             try? await Task.sleep(nanoseconds: 10_000_000_000)  // 10 seconds
 
-            // If the setup task is still registered, treat it as timed out.
+            // If the setup task is still registered, treat it as timed out,
+            // unless it is waiting on the approval dialog.
             if self.connectionTasks[connectionID] != nil,
-                self.connections[connectionID] != nil
+                self.connections[connectionID] != nil,
+                !self.connectionsAwaitingApproval.contains(connectionID)
             {
                 log.warning(
                     "Connection \(connectionID) setup timed out (task still in registry), closing it"

--- a/App/Controllers/ServerController.swift
+++ b/App/Controllers/ServerController.swift
@@ -628,10 +628,11 @@ actor ServerNetworkManager {
     private var discoveryManager: NetworkDiscoveryManager?
     private var connections: [UUID: MCPConnectionManager] = [:]
     private var connectionTasks: [UUID: Task<Void, Never>] = [:]
-    /// Connections whose setup is waiting on the user's approval decision.
-    /// The setup timeout leaves these alone:
-    /// the person reading the dialog is not a stalled handshake.
-    private var connectionsAwaitingApproval: Set<UUID> = []
+    /// Setup timers, keyed by connection.
+    /// A timer is cancelled while the user is deciding on the approval dialog
+    /// and started again with a fresh budget once they have,
+    /// so human deliberation never counts as a stalled handshake (#193).
+    private var setupTimeoutTasks: [UUID: Task<Void, Never>] = [:]
     private var pendingConnections: [UUID: String] = [:]
     private var removedConnections: Set<UUID> = []
 
@@ -818,6 +819,7 @@ actor ServerNetworkManager {
             // Ensure this task is removed so the timeout logic doesn't fire afterward.
             defer {
                 self.connectionTasks.removeValue(forKey: connectionID)
+                self.cancelSetupTimeout(for: connectionID)
             }
 
             do {
@@ -828,11 +830,15 @@ actor ServerNetworkManager {
                 }
 
                 try await connectionManager.start { clientInfo in
-                    // From here the wait is on a person, not the client,
-                    // so exempt the connection from the setup timeout (#193).
-                    self.connectionsAwaitingApproval.insert(connectionID)
-                    defer { self.connectionsAwaitingApproval.remove(connectionID) }
-                    return await approvalHandler(connectionID, clientInfo)
+                    // From here the wait is on a person, not the client:
+                    // stop the setup timer for the dialog
+                    // and restart it for the rest of the handshake afterwards.
+                    self.cancelSetupTimeout(for: connectionID)
+                    let approved = await approvalHandler(connectionID, clientInfo)
+                    if approved {
+                        self.scheduleSetupTimeout(for: connectionID)
+                    }
+                    return approved
                 }
 
                 log.notice("Connection \(connectionID) successfully established")
@@ -845,14 +851,21 @@ actor ServerNetworkManager {
         connectionTasks[connectionID] = task
 
         // Time out stalled setups to avoid orphaned connections.
-        Task {
-            try? await Task.sleep(nanoseconds: 10_000_000_000)  // 10 seconds
+        scheduleSetupTimeout(for: connectionID)
+    }
 
-            // If the setup task is still registered, treat it as timed out,
-            // unless it is waiting on the approval dialog.
+    /// Gives the connection a fresh setup budget.
+    /// Any previous timer for it is replaced.
+    private func scheduleSetupTimeout(for connectionID: UUID) {
+        setupTimeoutTasks[connectionID]?.cancel()
+        setupTimeoutTasks[connectionID] = Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)  // 10 seconds
+            guard !Task.isCancelled else { return }
+            self.setupTimeoutTasks.removeValue(forKey: connectionID)
+
+            // If the setup task is still registered, treat it as timed out.
             if self.connectionTasks[connectionID] != nil,
-                self.connections[connectionID] != nil,
-                !self.connectionsAwaitingApproval.contains(connectionID)
+                self.connections[connectionID] != nil
             {
                 log.warning(
                     "Connection \(connectionID) setup timed out (task still in registry), closing it"
@@ -860,6 +873,10 @@ actor ServerNetworkManager {
                 await removeConnection(connectionID)
             }
         }
+    }
+
+    private func cancelSetupTimeout(for connectionID: UUID) {
+        setupTimeoutTasks.removeValue(forKey: connectionID)?.cancel()
     }
 
     func registerHandlers(for server: MCP.Server, connectionID: UUID) async {


### PR DESCRIPTION
Fixes #193.

`handleNewConnection` races setup against a 10-second stall timer, but setup includes waiting for the person to answer the approval dialog. A first connection from an untrusted client was torn down before anyone could click Allow, which is exactly the "first attempt fails, retry works" pattern reported here and in #24.

The connection is now recorded as awaiting approval for the duration of the approval handler, and the timeout check skips it. The handshake before the prompt is still covered by the timer, and a denied dialog still closes the connection through the existing path.

No automated test: the app target has no test bundle, and this sits behind the approval UI. Verified by build; a manual check is connecting a fresh client and waiting longer than 10 seconds before clicking Allow.
