### PR TITLE
Bump Madrid to 0.5.0 and adopt FetchRequest<Message>

### DIFF
--- a/App/Services/Messages.swift
+++ b/App/Services/Messages.swift
@@ -128,11 +128,20 @@ final class MessageService: NSObject, Service, NSOpenSavePanelDelegate {
             log.debug(
                 "Fetching messages with date range: \(String(describing: dateRange)), limit: \(limit ?? -1)"
             )
-            for message in try db.fetchMessages(
-                with: Set(handles),
-                in: dateRange,
+            // Match the old fetchMessages(with:in:limit:) semantics:
+            // no participant filter when no handles matched.
+            var predicates: [MessagePredicate] = []
+            if !handles.isEmpty {
+                predicates.append(.participantHandles(Set(handles)))
+            }
+            if let dateRange {
+                predicates.append(.dateRange(dateRange))
+            }
+            let request = FetchRequest<Message>(
+                predicate: .and(predicates),
                 limit: max(limit ?? defaultLimit, 1024)
-            ) {
+            )
+            for message in try db.fetch(request) {
                 guard messages.count < (limit ?? defaultLimit) else { break }
                 guard !message.text.isEmpty else { continue }
 

--- a/iMCP.xcodeproj/project.pbxproj
+++ b/iMCP.xcodeproj/project.pbxproj
@@ -717,7 +717,7 @@
 			repositoryURL = "https://github.com/loopwork-ai/madrid";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.5.0;
 			};
 		};
 		F825BDBD2D9AD00E0063ADD7 /* XCRemoteSwiftPackageReference "swift-service-lifecycle" */ = {

--- a/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iMCP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/loopwork-ai/madrid",
       "state" : {
-        "revision" : "9d9fdb20424483fb592e5a026d9d0816cd5c43eb",
-        "version" : "0.1.0"
+        "revision" : "11ec80cb67700e47948f90cef6de38bce4dbfb12",
+        "version" : "0.5.0"
       }
     },
     {


### PR DESCRIPTION
Bumps Madrid from 0.1.0 to 0.5.0.

Madrid 0.4.0 deprecated `fetchMessages(with:in:limit:)`, and this project treats warnings as errors, so any bump past 0.1.0 failed the build at the one call in `Messages.swift` (which is why #195 doesn't build as-is). That call now uses `fetch(_:)` with an equivalent predicate: participant handles when any matched, and the date range when given.

0.5.0 also reads the Messages write-ahead log by default (so recent messages aren't hours stale) and exposes `Message.chatID`, which #197 and #198 build on.
