### PR TITLE
Stop caching Xcode's module cache between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
               with:
                   path: |
                       ~/Library/Developer/Xcode/DerivedData
+                      !~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
                       ~/Library/Caches/org.swift.swiftpm
                   key: ${{ runner.os }}-xcode-${{ matrix.xcode }}-derived-${{ hashFiles('**/Package.resolved') }}
                   restore-keys: |


### PR DESCRIPTION
`main` went red on the #188 merge with `Clang dependency scanner failure: ... AvailabilityVersions.h has been modified since the module file ... was built: mtime changed`. Nothing in that PR touches the build; the runner image updated its Xcode 26.0.1 SDK between runs, and the cached `ModuleCache.noindex` from an earlier run was restored on top of it. Module files are keyed to header mtimes, so the whole cache is rejected.

This excludes the module cache from what `actions/cache` saves. DerivedData and the SwiftPM cache are still cached; rebuilding modules takes seconds.
