### PR TITLE
Rotate the Sparkle public key

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -13,6 +13,6 @@
 	<key>SUFeedURL</key>
 	<string>https://downloads.imcp.app/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>+2ibtYfPSNKpUJsn1R9Ywc1GnjQA5vemVN95d0EzGxg=</string>
+	<string>TOvMWGidcnJi5xIqSmkkYFolRFpmHLLpO9GYVZfDC1U=</string>
 </dict>
 </plist>


### PR DESCRIPTION
Replaces `SUPublicEDKey` in `App/Info.plist` with a freshly generated key. The private half of the previous key wasn't available, and no shipped build contains Sparkle yet, so nothing in the field verifies against the old one. The 1.4.1 appcast served at `downloads.imcp.app` is signed with the new key; #180 should merge after this.