### PR TITLE
Automate releases with GitHub Actions and a Sparkle appcast step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,16 @@ jobs:
               if: github.event_name == 'workflow_dispatch' && inputs.dry_run
               run: echo "DRY_RUN=1" >> "${GITHUB_ENV}"
 
+            # A manual publish must run from the version's tag,
+            # so the release's source matches the binary it ships.
+            - name: Require the release tag
+              if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+              run: |
+                  if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != "${VERSION}" ]]; then
+                    echo "Publishing runs must be started from the ${VERSION} tag, not ${GITHUB_REF_TYPE} ${GITHUB_REF_NAME}." >&2
+                    exit 1
+                  fi
+
             - name: Import signing certificate
               env:
                   CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
@@ -154,7 +164,14 @@ jobs:
             - name: Package
               run: ./Scripts/release.sh package
 
-            - name: Create GitHub release
+            - name: Generate appcast
+              env:
+                  SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
+              run: ./Scripts/release.sh appcast
+
+            # Everything is built and validated before anything is published.
+            # The release stays a draft until both uploads have succeeded.
+            - name: Create draft release
               env:
                   GH_TOKEN: ${{ github.token }}
               run: ./Scripts/release.sh release
@@ -164,11 +181,15 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
               run: ./Scripts/release.sh upload
 
-            - name: Generate and upload appcast
+            - name: Upload appcast
               env:
                   GH_TOKEN: ${{ github.token }}
-                  SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
-              run: ./Scripts/release.sh appcast
+              run: ./Scripts/release.sh upload-appcast
+
+            - name: Publish release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: ./Scripts/release.sh publish
 
             - name: Attach build products to the workflow run
               if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,190 @@
+name: Release
+
+# Builds, signs, notarizes, and publishes a release
+# with the same Scripts/release.sh steps used locally.
+#
+# A pushed version tag (for example 1.5.0) runs the full flow.
+# Manual runs default to a dry run,
+# which does everything except create the GitHub release and upload assets;
+# the artifacts are attached to the workflow run instead.
+
+on:
+    push:
+        tags: ["[0-9]+.[0-9]+.[0-9]+"]
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "Version to release (defaults to the tag name when run from a tag)"
+                required: false
+                type: string
+            dry_run:
+                description: "Skip creating the GitHub release and uploading assets"
+                required: false
+                type: boolean
+                default: true
+
+permissions:
+    contents: write
+
+concurrency:
+    group: release-${{ github.ref }}
+    cancel-in-progress: false
+
+env:
+    DEVELOPER_DIR: "/Applications/Xcode_26.0.app/Contents/Developer"
+    TEAM_ID: TTY35UM57S
+    SIGNING_CERTIFICATE: "Developer ID Application: dododo, LLC (TTY35UM57S)"
+    SPARKLE_VERSION: "2.9.6"
+    SPARKLE_SHA256: "52bf9e88cdd972fc0c81501377a880e90d47031bd8ca5462488f843e2609e192"
+
+jobs:
+    release:
+        name: Build, notarize, and publish
+        runs-on: macos-26
+        timeout-minutes: 60
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Resolve version
+              id: version
+              env:
+                  INPUT_VERSION: ${{ inputs.version }}
+              run: |
+                  if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+                    version="${GITHUB_REF_NAME}"
+                  else
+                    version="${INPUT_VERSION}"
+                  fi
+                  if [[ -z "${version}" ]]; then
+                    echo "No version: push a version tag or pass the version input." >&2
+                    exit 1
+                  fi
+                  project_version="$(grep -m1 -o 'MARKETING_VERSION = [0-9.]*' iMCP.xcodeproj/project.pbxproj | awk '{print $3}')"
+                  if [[ "${project_version}" != "${version}" ]]; then
+                    echo "MARKETING_VERSION in the project is ${project_version}, not ${version}." >&2
+                    exit 1
+                  fi
+                  echo "VERSION=${version}" >> "${GITHUB_ENV}"
+
+            # Tag pushes always publish; manual runs publish only when dry_run is off.
+            - name: Note dry run
+              if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+              run: echo "DRY_RUN=1" >> "${GITHUB_ENV}"
+
+            - name: Import signing certificate
+              env:
+                  CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+                  CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+              run: |
+                  keychain="${RUNNER_TEMP}/release.keychain-db"
+                  keychain_password="$(uuidgen)"
+                  certificate="${RUNNER_TEMP}/certificate.p12"
+                  echo "${CERTIFICATE_P12}" | base64 --decode > "${certificate}"
+                  security create-keychain -p "${keychain_password}" "${keychain}"
+                  security set-keychain-settings -lut 21600 "${keychain}"
+                  security unlock-keychain -p "${keychain_password}" "${keychain}"
+                  security import "${certificate}" -P "${CERTIFICATE_PASSWORD}" -A -t cert -f pkcs12 -k "${keychain}"
+                  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${keychain_password}" "${keychain}" > /dev/null
+                  security list-keychains -d user -s "${keychain}" login.keychain-db
+                  rm -f "${certificate}"
+                  security find-identity -v -p codesigning "${keychain}"
+                  echo "RELEASE_KEYCHAIN=${keychain}" >> "${GITHUB_ENV}"
+
+            - name: Install provisioning profile
+              env:
+                  PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE }}
+              run: |
+                  profile="${RUNNER_TEMP}/profile.provisionprofile"
+                  echo "${PROVISIONING_PROFILE}" | base64 --decode > "${profile}"
+                  plist="${RUNNER_TEMP}/profile.plist"
+                  security cms -D -i "${profile}" > "${plist}"
+                  uuid="$(/usr/libexec/PlistBuddy -c "Print UUID" "${plist}")"
+                  for dir in "${HOME}/Library/MobileDevice/Provisioning Profiles" "${HOME}/Library/Developer/Xcode/UserData/Provisioning Profiles"; do
+                    mkdir -p "${dir}"
+                    cp "${profile}" "${dir}/${uuid}.provisionprofile"
+                  done
+                  echo "PROVISIONING_PROFILE_UUID=${uuid}" >> "${GITHUB_ENV}"
+                  /usr/libexec/PlistBuddy -c "Print Name" "${plist}"
+
+            - name: Write notarization key
+              env:
+                  APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+              run: |
+                  key="${RUNNER_TEMP}/AuthKey.p8"
+                  printf '%s\n' "${APP_STORE_CONNECT_PRIVATE_KEY}" > "${key}"
+                  chmod 600 "${key}"
+                  echo "NOTARY_KEY_FILE=${key}" >> "${GITHUB_ENV}"
+
+            - name: Install Sparkle tools
+              run: |
+                  archive="${RUNNER_TEMP}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+                  curl -sSL -o "${archive}" "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+                  echo "${SPARKLE_SHA256}  ${archive}" | shasum -a 256 -c -
+                  mkdir -p "${RUNNER_TEMP}/sparkle"
+                  tar -xJf "${archive}" -C "${RUNNER_TEMP}/sparkle" ./bin/generate_appcast ./bin/sign_update
+                  echo "SPARKLE_BIN=${RUNNER_TEMP}/sparkle/bin" >> "${GITHUB_ENV}"
+
+            - name: Write Sparkle signing key
+              env:
+                  SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+              run: |
+                  key="${RUNNER_TEMP}/sparkle_private_key"
+                  printf '%s' "${SPARKLE_PRIVATE_KEY}" > "${key}"
+                  chmod 600 "${key}"
+                  echo "SPARKLE_PRIVATE_KEY_FILE=${key}" >> "${GITHUB_ENV}"
+
+            - name: Archive
+              run: ./Scripts/release.sh archive
+
+            - name: Export
+              run: ./Scripts/release.sh export
+
+            - name: Notarize
+              env:
+                  NOTARY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+                  NOTARY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+              run: ./Scripts/release.sh notarize
+
+            - name: Staple
+              run: |
+                  ./Scripts/release.sh staple
+                  xcrun stapler validate dist/export/*.app
+
+            - name: Package
+              run: ./Scripts/release.sh package
+
+            - name: Create GitHub release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: ./Scripts/release.sh release
+
+            - name: Upload release asset
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: ./Scripts/release.sh upload
+
+            - name: Generate and upload appcast
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
+              run: ./Scripts/release.sh appcast
+
+            - name: Attach build products to the workflow run
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: iMCP-${{ env.VERSION }}
+                  path: |
+                      dist/*.zip
+                      dist/*.sha256
+                      dist/appcast/appcast.xml
+                  if-no-files-found: ignore
+
+            - name: Clean up secrets
+              if: always()
+              run: |
+                  rm -f "${RUNNER_TEMP}/sparkle_private_key" "${RUNNER_TEMP}/AuthKey.p8" "${RUNNER_TEMP}/profile.provisionprofile"
+                  if [[ -n "${RELEASE_KEYCHAIN:-}" && -f "${RELEASE_KEYCHAIN}" ]]; then
+                    security delete-keychain "${RELEASE_KEYCHAIN}"
+                  fi

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -490,6 +490,17 @@ require_release_tag() {
     echo "Tag ${VERSION} points at ${tag_commit}, but HEAD is ${head_commit}." >&2
     exit 1
   fi
+  # The remote tag is what the release records, so it must exist and match too.
+  local remote_commit
+  remote_commit="$(git ls-remote --tags origin "refs/tags/${VERSION}^{}" "refs/tags/${VERSION}" 2>/dev/null | awk '{print $1}' | tail -n 1 || true)"
+  if [[ -z "${remote_commit}" ]]; then
+    echo "Tag ${VERSION} hasn't been pushed to origin." >&2
+    exit 1
+  fi
+  if [[ "${remote_commit}" != "${tag_commit}" && "${remote_commit}" != "$(git rev-parse "refs/tags/${VERSION}")" ]]; then
+    echo "Tag ${VERSION} on origin (${remote_commit}) doesn't match the local tag (${tag_commit})." >&2
+    exit 1
+  fi
 }
 
 # The release starts as a draft so a failure partway through
@@ -513,7 +524,7 @@ create_release() {
     exit 1
   fi
   echo "Creating draft GitHub release ${VERSION}"
-  gh release create "${VERSION}" --draft --generate-notes
+  gh release create "${VERSION}" --draft --generate-notes --verify-tag
 }
 
 publish_release() {

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -19,6 +19,16 @@ SIGNING_CERTIFICATE="${SIGNING_CERTIFICATE:-Developer ID Application}"
 BUNDLE_ID="${BUNDLE_ID:-}"
 PROVISIONING_PROFILE_NAME="${PROVISIONING_PROFILE_NAME:-}"
 PROVISIONING_PROFILE_UUID="${PROVISIONING_PROFILE_UUID:-}"
+NOTARY_KEY_ID="${NOTARY_KEY_ID:-}"
+NOTARY_ISSUER_ID="${NOTARY_ISSUER_ID:-}"
+NOTARY_KEY_FILE="${NOTARY_KEY_FILE:-}"
+SPARKLE_BIN="${SPARKLE_BIN:-}"
+SPARKLE_PRIVATE_KEY_FILE="${SPARKLE_PRIVATE_KEY_FILE:-}"
+SPARKLE_PUBLIC_KEY="${SPARKLE_PUBLIC_KEY:-}"
+APPCAST_DIR="${APPCAST_DIR:-${DIST_DIR}/appcast}"
+APPCAST_LINK="${APPCAST_LINK:-https://imcp.app}"
+RELEASE_DOWNLOAD_BASE="${RELEASE_DOWNLOAD_BASE:-https://github.com/mattt/iMCP/releases/download}"
+DRY_RUN="${DRY_RUN:-}"
 
 # Derived artifact names for notarization/release steps.
 NOTARY_ZIP="${DIST_DIR}/${APP_NAME}-notarize.zip"
@@ -28,7 +38,7 @@ print_usage() {
 Usage: Scripts/release.sh [command]
 
 Commands:
-  all         Build check, bump, archive, export, package, notarize, staple, commit/tag, release, upload (default)
+  all         Build check, bump, archive, export, notarize, staple, package, commit/tag, release, upload, appcast (default)
   check       Quick release build check
   bump        Bump version/build numbers
   archive     Create an Xcode archive for direct distribution
@@ -40,12 +50,16 @@ Commands:
   commit      Commit version bump and create release tag
   release     Create a GitHub release (no assets)
   upload      Upload the release asset to GitHub
+  appcast     Generate the signed Sparkle appcast and upload it to the release
   help        Show this help
 
 Environment:
   APP_NAME          App name (default: iMCP)
   APP_BUNDLE        App bundle path (default: ${APP_NAME}.app)
-  KEYCHAIN_PROFILE  Required for notarize
+  KEYCHAIN_PROFILE  notarytool keychain profile (notarize; or set the NOTARY_* keys)
+  NOTARY_KEY_ID     App Store Connect API key ID (notarize, alternative to KEYCHAIN_PROFILE)
+  NOTARY_ISSUER_ID  App Store Connect API issuer ID (with NOTARY_KEY_ID)
+  NOTARY_KEY_FILE   Path to the App Store Connect API .p8 key (with NOTARY_KEY_ID)
   VERSION           Required for bumping, commit, release, and upload
   BUILD_NUMBER      Optional; used when bumping build number
   SCHEME            Xcode scheme for build check (default: iMCP)
@@ -61,6 +75,13 @@ Environment:
   BUNDLE_ID         Bundle identifier for export profiles (optional)
   PROVISIONING_PROFILE_NAME Provisioning profile name for export (optional)
   PROVISIONING_PROFILE_UUID Provisioning profile UUID for export (optional)
+  SPARKLE_BIN       Directory containing Sparkle's generate_appcast (default: found in DerivedData or PATH)
+  SPARKLE_PRIVATE_KEY_FILE Path to the Sparkle EdDSA private key (default: the login keychain)
+  SPARKLE_PUBLIC_KEY Expected SUPublicEDKey; the appcast step fails if the app carries a different key (optional)
+  APPCAST_DIR       Working directory for the appcast (default: dist/appcast)
+  APPCAST_LINK      Link element for appcast items (default: https://imcp.app)
+  RELEASE_DOWNLOAD_BASE Base URL for release assets (default: https://github.com/mattt/iMCP/releases/download)
+  DRY_RUN           If set, skip creating the GitHub release and uploading assets
 EOF
 }
 
@@ -93,11 +114,27 @@ require_app_bundle() {
   fi
 }
 
-require_keychain_profile() {
+# notarytool accepts either a stored keychain profile
+# or an App Store Connect API key passed explicitly.
+# The API key form is what CI uses.
+notary_credential_args() {
+  if [[ -n "${NOTARY_KEY_ID}" || -n "${NOTARY_ISSUER_ID}" || -n "${NOTARY_KEY_FILE}" ]]; then
+    if [[ -z "${NOTARY_KEY_ID}" || -z "${NOTARY_ISSUER_ID}" || -z "${NOTARY_KEY_FILE}" ]]; then
+      echo "NOTARY_KEY_ID, NOTARY_ISSUER_ID, and NOTARY_KEY_FILE must be set together." >&2
+      exit 1
+    fi
+    if [[ ! -f "${NOTARY_KEY_FILE}" ]]; then
+      echo "Missing notary key file: ${NOTARY_KEY_FILE}" >&2
+      exit 1
+    fi
+    printf '%s\n' "--key" "${NOTARY_KEY_FILE}" "--key-id" "${NOTARY_KEY_ID}" "--issuer" "${NOTARY_ISSUER_ID}"
+    return 0
+  fi
   if [[ -z "${KEYCHAIN_PROFILE}" ]]; then
-    echo "Missing keychain profile. Set KEYCHAIN_PROFILE." >&2
+    echo "Missing notarization credentials. Set KEYCHAIN_PROFILE, or NOTARY_KEY_ID, NOTARY_ISSUER_ID, and NOTARY_KEY_FILE." >&2
     exit 1
   fi
+  printf '%s\n' "--keychain-profile" "${KEYCHAIN_PROFILE}"
 }
 
 require_version() {
@@ -326,12 +363,15 @@ export_app() {
 
 notarize() {
   require_app_bundle
-  require_keychain_profile
+  local credential_args=()
+  while IFS= read -r line; do
+    credential_args+=("${line}")
+  done < <(notary_credential_args)
   ensure_dist_dir
   echo "Zipping for notarization: ${NOTARY_ZIP}"
   ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARY_ZIP}"
   echo "Submitting to notarization"
-  xcrun notarytool submit "${NOTARY_ZIP}" --wait --keychain-profile="${KEYCHAIN_PROFILE}"
+  xcrun notarytool submit "${NOTARY_ZIP}" --wait "${credential_args[@]}"
 }
 
 staple() {
@@ -397,6 +437,10 @@ push_tags() {
 
 create_release() {
   require_version
+  if [[ -n "${DRY_RUN}" ]]; then
+    echo "Dry run: would create GitHub release ${VERSION}"
+    return 0
+  fi
   echo "Creating GitHub release ${VERSION}"
   gh release create "${VERSION}" --generate-notes
 }
@@ -413,9 +457,116 @@ upload_asset() {
   if [[ "${release_zip_path}" != "${upload_path}" ]]; then
     cp -f "${release_zip_path}" "${upload_path}"
   fi
+  if [[ -n "${DRY_RUN}" ]]; then
+    echo "Dry run: would upload ${upload_path} to release ${VERSION}"
+    return 0
+  fi
   echo "Uploading release asset ${upload_path}"
   gh release upload "${VERSION}" "${upload_path}" --clobber
-  gh release view --web "${VERSION}"
+  if [[ -t 1 && -z "${CI:-}" ]]; then
+    gh release view --web "${VERSION}"
+  fi
+}
+
+# Sparkle ships generate_appcast inside its SwiftPM artifact,
+# so look there before falling back to PATH.
+resolve_sparkle_bin() {
+  if [[ -n "${SPARKLE_BIN}" ]]; then
+    if [[ ! -x "${SPARKLE_BIN}/generate_appcast" ]]; then
+      echo "generate_appcast not found in SPARKLE_BIN: ${SPARKLE_BIN}" >&2
+      exit 1
+    fi
+    return 0
+  fi
+  local candidate
+  candidate="$(find "${HOME}/Library/Developer/Xcode/DerivedData" -type f -path '*/artifacts/sparkle/Sparkle/bin/generate_appcast' 2>/dev/null | head -n 1 || true)"
+  if [[ -n "${candidate}" ]]; then
+    SPARKLE_BIN="$(dirname "${candidate}")"
+    return 0
+  fi
+  if command -v generate_appcast >/dev/null 2>&1; then
+    SPARKLE_BIN="$(dirname "$(command -v generate_appcast)")"
+    return 0
+  fi
+  echo "Sparkle's generate_appcast was not found. Set SPARKLE_BIN to its directory." >&2
+  exit 1
+}
+
+# The app must embed the public half of the key that signs the appcast,
+# or Sparkle refuses the update on the client.
+verify_sparkle_public_key() {
+  if [[ -z "${SPARKLE_PUBLIC_KEY}" ]]; then
+    return 0
+  fi
+  require_app_bundle
+  local embedded_key
+  embedded_key="$("/usr/libexec/PlistBuddy" -c "Print SUPublicEDKey" "${APP_BUNDLE}/Contents/Info.plist" 2>/dev/null || true)"
+  if [[ "${embedded_key}" != "${SPARKLE_PUBLIC_KEY}" ]]; then
+    echo "SUPublicEDKey in ${APP_BUNDLE} does not match SPARKLE_PUBLIC_KEY." >&2
+    echo "  app:      ${embedded_key:-<missing>}" >&2
+    echo "  expected: ${SPARKLE_PUBLIC_KEY}" >&2
+    exit 1
+  fi
+}
+
+build_appcast() {
+  require_version
+  resolve_sparkle_bin
+  verify_sparkle_public_key
+  local release_zip_path
+  release_zip_path="$(release_zip)"
+  if [[ ! -f "${release_zip_path}" ]]; then
+    echo "Missing release asset: ${release_zip_path}" >&2
+    exit 1
+  fi
+  # generate_appcast reads every archive in its directory,
+  # so give it a directory holding only this release,
+  # named as the asset is named on GitHub.
+  rm -rf "${APPCAST_DIR}"
+  mkdir -p "${APPCAST_DIR}"
+  cp -f "${release_zip_path}" "${APPCAST_DIR}/${APP_NAME}.zip"
+  local key_args=()
+  if [[ -n "${SPARKLE_PRIVATE_KEY_FILE}" ]]; then
+    if [[ ! -f "${SPARKLE_PRIVATE_KEY_FILE}" ]]; then
+      echo "Missing Sparkle private key file: ${SPARKLE_PRIVATE_KEY_FILE}" >&2
+      exit 1
+    fi
+    key_args=(--ed-key-file "${SPARKLE_PRIVATE_KEY_FILE}")
+  fi
+  echo "Generating appcast in ${APPCAST_DIR}"
+  # macOS ships bash 3.2, where an empty array trips set -u.
+  "${SPARKLE_BIN}/generate_appcast" \
+    ${key_args[@]+"${key_args[@]}"} \
+    --download-url-prefix "${RELEASE_DOWNLOAD_BASE}/${VERSION}/" \
+    --link "${APPCAST_LINK}" \
+    "${APPCAST_DIR}"
+  local appcast_path="${APPCAST_DIR}/appcast.xml"
+  if [[ ! -f "${appcast_path}" ]]; then
+    echo "generate_appcast did not write ${appcast_path}" >&2
+    exit 1
+  fi
+  # generate_appcast leaves the signature off silently
+  # when the app's SUPublicEDKey doesn't match the signing key.
+  if ! grep -q 'sparkle:edSignature="' "${appcast_path}"; then
+    echo "Appcast item is unsigned. Check that SUPublicEDKey in the app matches the Sparkle private key." >&2
+    exit 1
+  fi
+  echo "Done: ${appcast_path}"
+}
+
+upload_appcast() {
+  require_version
+  local appcast_path="${APPCAST_DIR}/appcast.xml"
+  if [[ ! -f "${appcast_path}" ]]; then
+    echo "Missing appcast: ${appcast_path}" >&2
+    exit 1
+  fi
+  if [[ -n "${DRY_RUN}" ]]; then
+    echo "Dry run: would upload ${appcast_path} to release ${VERSION}"
+    return 0
+  fi
+  echo "Uploading appcast to release ${VERSION}"
+  gh release upload "${VERSION}" "${appcast_path}" --clobber
 }
 
 all() {
@@ -425,13 +576,20 @@ all() {
   bump_version
   archive_app
   export_app
-  package_release
   notarize
   staple
+  package_release
   commit_and_tag
   push_tags
   create_release
   upload_asset
+  build_appcast
+  upload_appcast
+}
+
+appcast() {
+  build_appcast
+  upload_appcast
 }
 
 release() {
@@ -482,6 +640,9 @@ case "${COMMAND}" in
     ;;
   upload)
     upload
+    ;;
+  appcast)
+    appcast
     ;;
   help|-h|--help)
     print_usage

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -467,12 +467,13 @@ push_tags() {
     exit 1
   fi
   local response=""
-  read -r -p "Push tags to origin? [y/N] " response
+  read -r -p "Push tag ${VERSION} to origin? [y/N] " response
   if [[ "${response}" != "y" && "${response}" != "Y" ]]; then
     echo "Tag push cancelled."
     exit 1
   fi
-  git push --tags
+  # Push only this release's tag: every pushed version tag starts a release.
+  git push origin "refs/tags/${VERSION}"
 }
 
 # The release tag must exist and point at the commit being released,

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -38,7 +38,7 @@ print_usage() {
 Usage: Scripts/release.sh [command]
 
 Commands:
-  all         Build check, bump, archive, export, notarize, staple, package, commit/tag, release, upload, appcast (default)
+  all         Build check, bump, archive, export, notarize, staple, package, commit/tag, appcast, release, upload, upload-appcast, publish (default)
   check       Quick release build check
   bump        Bump version/build numbers
   archive     Create an Xcode archive for direct distribution
@@ -48,9 +48,11 @@ Commands:
   notarize    Submit the app bundle for notarization
   staple      Staple the notarization ticket to the app bundle
   commit      Commit version bump and create release tag
-  release     Create a GitHub release (no assets)
-  upload      Upload the release asset to GitHub
-  appcast     Generate the signed Sparkle appcast and upload it to the release
+  appcast     Generate and validate the signed Sparkle appcast
+  release     Create a draft GitHub release for the tag at HEAD (no assets)
+  upload      Upload the release asset to the draft release
+  upload-appcast Upload the appcast to the draft release
+  publish     Publish the draft release and mark it latest
   help        Show this help
 
 Environment:
@@ -363,10 +365,14 @@ export_app() {
 
 notarize() {
   require_app_bundle
+  # Capture first so a validation failure in the helper stops the script;
+  # a process substitution would swallow its exit status.
+  local credential_output
+  credential_output="$(notary_credential_args)"
   local credential_args=()
   while IFS= read -r line; do
     credential_args+=("${line}")
-  done < <(notary_credential_args)
+  done <<< "${credential_output}"
   ensure_dist_dir
   echo "Zipping for notarization: ${NOTARY_ZIP}"
   ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARY_ZIP}"
@@ -435,14 +441,47 @@ push_tags() {
   git push --tags
 }
 
+# The release tag must exist and point at the commit being released,
+# or gh would mint a tag on the default branch that doesn't match the binary.
+require_release_tag() {
+  require_version
+  local tag_commit head_commit
+  tag_commit="$(git rev-list -n 1 "refs/tags/${VERSION}" 2>/dev/null || true)"
+  if [[ -z "${tag_commit}" ]]; then
+    echo "Missing tag: ${VERSION}. Tag the release commit before publishing." >&2
+    exit 1
+  fi
+  head_commit="$(git rev-parse HEAD)"
+  if [[ "${tag_commit}" != "${head_commit}" ]]; then
+    echo "Tag ${VERSION} points at ${tag_commit}, but HEAD is ${head_commit}." >&2
+    exit 1
+  fi
+}
+
+# The release starts as a draft so a failure partway through
+# never leaves a half-populated release as the latest one.
 create_release() {
   require_version
   if [[ -n "${DRY_RUN}" ]]; then
-    echo "Dry run: would create GitHub release ${VERSION}"
+    echo "Dry run: would create draft GitHub release ${VERSION}"
     return 0
   fi
-  echo "Creating GitHub release ${VERSION}"
-  gh release create "${VERSION}" --generate-notes
+  require_release_tag
+  echo "Creating draft GitHub release ${VERSION}"
+  gh release create "${VERSION}" --draft --generate-notes
+}
+
+publish_release() {
+  require_version
+  if [[ -n "${DRY_RUN}" ]]; then
+    echo "Dry run: would publish GitHub release ${VERSION}"
+    return 0
+  fi
+  echo "Publishing GitHub release ${VERSION}"
+  gh release edit "${VERSION}" --draft=false --latest
+  if [[ -t 1 && -z "${CI:-}" ]]; then
+    gh release view --web "${VERSION}"
+  fi
 }
 
 upload_asset() {
@@ -463,9 +502,6 @@ upload_asset() {
   fi
   echo "Uploading release asset ${upload_path}"
   gh release upload "${VERSION}" "${upload_path}" --clobber
-  if [[ -t 1 && -z "${CI:-}" ]]; then
-    gh release view --web "${VERSION}"
-  fi
 }
 
 # Sparkle ships generate_appcast inside its SwiftPM artifact,
@@ -581,15 +617,15 @@ all() {
   package_release
   commit_and_tag
   push_tags
+  build_appcast
   create_release
   upload_asset
-  build_appcast
   upload_appcast
+  publish_release
 }
 
 appcast() {
   build_appcast
-  upload_appcast
 }
 
 release() {
@@ -643,6 +679,12 @@ case "${COMMAND}" in
     ;;
   appcast)
     appcast
+    ;;
+  upload-appcast)
+    upload_appcast
+    ;;
+  publish)
+    publish_release
     ;;
   help|-h|--help)
     print_usage

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -38,7 +38,7 @@ print_usage() {
 Usage: Scripts/release.sh [command]
 
 Commands:
-  all         Build check, bump, archive, export, notarize, staple, package, commit/tag, appcast, release, upload, upload-appcast, publish (default)
+  all         Build check, bump, archive, export, notarize, staple, package, commit/tag, push tag (default); the Release workflow publishes
   check       Quick release build check
   bump        Bump version/build numbers
   archive     Create an Xcode archive for direct distribution
@@ -302,10 +302,44 @@ build_check() {
   resolve_app_bundle
 }
 
+# The project's Release configuration signs the app with an Apple Development identity,
+# which a release machine may not have.
+# When a Developer ID certificate is configured, archive with it directly;
+# export re-signs with the provisioning profile afterwards.
+archive_signing_args() {
+  if [[ -z "${TEAM_ID}" ]]; then
+    return 0
+  fi
+  printf '%s\n' \
+    "CODE_SIGN_STYLE=Manual" \
+    "CODE_SIGN_IDENTITY=${SIGNING_CERTIFICATE}" \
+    "DEVELOPMENT_TEAM=${TEAM_ID}"
+  # The app's WeatherKit entitlement needs its provisioning profile at archive time,
+  # but a command-line override applies to every target,
+  # and the embedded CLI has a different bundle identifier.
+  # Route the profile through a setting keyed by product name
+  # so only the app target resolves to it.
+  local profile_value=""
+  if [[ -n "${PROVISIONING_PROFILE_UUID}" ]]; then
+    profile_value="${PROVISIONING_PROFILE_UUID}"
+  elif [[ -n "${PROVISIONING_PROFILE_NAME}" ]]; then
+    profile_value="${PROVISIONING_PROFILE_NAME}"
+  fi
+  if [[ -n "${profile_value}" ]]; then
+    printf '%s\n' \
+      'PROVISIONING_PROFILE_SPECIFIER=$(RELEASE_PROFILE_FOR_$(PRODUCT_NAME))' \
+      "RELEASE_PROFILE_FOR_${APP_NAME}=${profile_value}"
+  fi
+}
+
 archive_app() {
   ensure_dist_dir
+  local signing_args=()
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] && signing_args+=("${line}")
+  done <<< "$(archive_signing_args)"
   echo "Archiving app to ${ARCHIVE_PATH}"
-  xcodebuild -quiet -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -destination "generic/platform=macOS" archive -archivePath "${ARCHIVE_PATH}"
+  xcodebuild -quiet -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -destination "generic/platform=macOS" archive -archivePath "${ARCHIVE_PATH}" ${signing_args[@]+"${signing_args[@]}"}
 }
 
 write_export_options() {
@@ -467,6 +501,17 @@ create_release() {
     return 0
   fi
   require_release_tag
+  # A rerun after a partial failure finds the draft from the last attempt;
+  # reuse it so the --clobber uploads can repair it.
+  local is_draft
+  if is_draft="$(gh release view "${VERSION}" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+    if [[ "${is_draft}" == "true" ]]; then
+      echo "Reusing existing draft release ${VERSION}"
+      return 0
+    fi
+    echo "Release ${VERSION} is already published." >&2
+    exit 1
+  fi
   echo "Creating draft GitHub release ${VERSION}"
   gh release create "${VERSION}" --draft --generate-notes
 }
@@ -617,11 +662,10 @@ all() {
   package_release
   commit_and_tag
   push_tags
-  build_appcast
-  create_release
-  upload_asset
-  upload_appcast
-  publish_release
+  # The Release workflow publishes from the pushed tag.
+  # Publishing here too would race it for the same release.
+  echo "Tag ${VERSION} pushed. The Release workflow builds and publishes it."
+  echo "Use the appcast, release, upload, upload-appcast, and publish commands only if it can't."
 }
 
 appcast() {


### PR DESCRIPTION
Pushing a version tag (e.g., `1.5.0`) will now build, sign, notarize, staple, package, and generate a signed Sparkle `appcast.xml`, then create a draft GitHub release, upload `iMCP.zip` and the appcast, and publish the release only once both uploads succeed.

Manual runs of the workflow default to a dry run that does everything except create the release and upload, and attach the build products to the run so they can be inspected. A manual run that publishes must be started from the version's tag.
