### PR TITLE
Key the CI cache on the Xcode build number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
 
+            # Key the cache on the exact Xcode build,
+            # so a runner image update can't restore module files
+            # compiled against an older toolchain.
+            - name: Read Xcode build number
+              id: xcode
+              run: echo "build=$(xcodebuild -version | awk '/Build version/ {print $3}')" >> "${GITHUB_OUTPUT}"
+
             - name: Cache Xcode build artifacts
               uses: actions/cache@v5
               with:
@@ -34,9 +41,9 @@ jobs:
                       ~/Library/Developer/Xcode/DerivedData
                       !~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
                       ~/Library/Caches/org.swift.swiftpm
-                  key: ${{ runner.os }}-xcode-${{ matrix.xcode }}-derived-${{ hashFiles('**/Package.resolved') }}
+                  key: ${{ runner.os }}-xcode-${{ steps.xcode.outputs.build }}-derived-${{ hashFiles('**/Package.resolved') }}
                   restore-keys: |
-                      ${{ runner.os }}-xcode-${{ matrix.xcode }}-derived-
+                      ${{ runner.os }}-xcode-${{ steps.xcode.outputs.build }}-derived-
 
             - name: Lint
               run: swift format lint --strict --recursive .


### PR DESCRIPTION
The DerivedData cache key only changed when `Package.resolved` did, so when the runner image moved to a newer Xcode the old cache, module files included, kept being restored and every build failed with "has been modified since the module file was built". The exclusion added in #202 never took effect because a cache hit is never re-saved; the fix today was deleting the caches by hand.

This reads the Xcode build number from `xcodebuild -version` and puts it in the cache key, so an image update starts a fresh cache.
