### PR TITLE
Drop the module cache before the CI cache is saved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,11 @@ jobs:
 
             - name: Build
               run: xcodebuild -quiet -scheme iMCP -configuration Debug -destination "platform=macOS" build
+
+            # The cache action's exclude pattern has not kept the module cache out of
+            # the archive, and runner images with the same Xcode build can differ in
+            # toolchain file timestamps, which makes a restored module cache fatal.
+            # Remove it before the cache is saved at the end of the job.
+            - name: Drop the module cache before saving
+              if: always()
+              run: rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex


### PR DESCRIPTION
Follow-up to #207. The key change there isn't enough on its own: two runner images report the same Xcode build number but differ in toolchain file timestamps, so a module cache saved on one is fatal on the other, and the cache action's exclude pattern hasn't been keeping `ModuleCache.noindex` out of the archive. This deletes it after the build, before the cache is saved at the end of the job.
